### PR TITLE
Course/Question Loader Context Unsub

### DIFF
--- a/src/app/context/UserSessionContext.tsx
+++ b/src/app/context/UserSessionContext.tsx
@@ -8,7 +8,7 @@ import {
   signInWithPopup,
   signOut,
 } from "firebase/auth";
-import React from "react";
+import React, { useRef } from "react";
 import { auth } from "@project/firebase";
 import { addUser, getUser } from "@services/client/user";
 import { useRouter } from "next/navigation";
@@ -43,7 +43,13 @@ export const UserSessionContextProvider = ({
   });
   const router = useRouter();
 
+  const isInitiated = useRef(false);
   React.useEffect(() => {
+    // TODO: on password change, add additional check
+    if (user !== null || isInitiated.current) {
+      return;
+    }
+    isInitiated.current = true;
     const unsub = onAuthStateChanged(auth, async (firebaseUser) => {
       if (firebaseUser) {
         const currUser = await getUser(firebaseUser?.uid);
@@ -56,7 +62,7 @@ export const UserSessionContextProvider = ({
         router.push("/");
       }
     });
-
+    console.log("subbing auth!");
     return () => unsub();
   }, []);
 

--- a/src/app/context/UserSessionContext.tsx
+++ b/src/app/context/UserSessionContext.tsx
@@ -8,7 +8,7 @@ import {
   signInWithPopup,
   signOut,
 } from "firebase/auth";
-import React, { useRef } from "react";
+import React from "react";
 import { auth } from "@project/firebase";
 import { addUser, getUser } from "@services/client/user";
 import { useRouter } from "next/navigation";

--- a/src/app/context/UserSessionContext.tsx
+++ b/src/app/context/UserSessionContext.tsx
@@ -62,10 +62,8 @@ export const UserSessionContextProvider = ({
         router.push("/");
       }
     });
-    console.log("subbing auth!");
     return () => unsub();
   }, []);
-
   const onSignIn = async () => {
     try {
       await setPersistence(auth, browserLocalPersistence);

--- a/src/app/context/UserSessionContext.tsx
+++ b/src/app/context/UserSessionContext.tsx
@@ -44,7 +44,6 @@ export const UserSessionContextProvider = ({
   const router = useRouter();
 
   React.useEffect(() => {
-    // TODO: on password change, add additional check
     const unsub = onAuthStateChanged(auth, async (firebaseUser) => {
       if (firebaseUser) {
         const currUser = await getUser(firebaseUser?.uid);

--- a/src/app/context/UserSessionContext.tsx
+++ b/src/app/context/UserSessionContext.tsx
@@ -43,13 +43,8 @@ export const UserSessionContextProvider = ({
   });
   const router = useRouter();
 
-  const isInitiated = useRef(false);
   React.useEffect(() => {
     // TODO: on password change, add additional check
-    if (user !== null || isInitiated.current) {
-      return;
-    }
-    isInitiated.current = true;
     const unsub = onAuthStateChanged(auth, async (firebaseUser) => {
       if (firebaseUser) {
         const currUser = await getUser(firebaseUser?.uid);

--- a/src/app/hooks/oh/useCourseLoader.tsx
+++ b/src/app/hooks/oh/useCourseLoader.tsx
@@ -29,8 +29,8 @@ export const useCourseLoader = (props: UseCourseLoaderProps) => {
     if (state.state !== State.SUCCESS) {
       if (unsubscriber.current !== null) {
         unsubscriber.current();
+        unsubscriber.current = null;
       }
-      unsubscriber.current = null;
       return;
     }
 
@@ -46,7 +46,12 @@ export const useCourseLoader = (props: UseCourseLoaderProps) => {
 
     unsubscriber.current = unsubscribe;
 
-    return unsubscriber.current();
+    return () => {
+      if (unsubscriber.current) {
+        unsubscriber.current();
+        unsubscriber.current = null;
+      }
+    };
   }, [state.state, courseId]);
 
   // TODO(lnguyen2693) - handle setError

--- a/src/app/hooks/oh/useQuestionsLoader.tsx
+++ b/src/app/hooks/oh/useQuestionsLoader.tsx
@@ -31,8 +31,8 @@ export const useQuestionsLoader = (props: UseQuestionsLoaderProps) => {
     if (state.state !== State.SUCCESS) {
       if (unsubscriber.current !== null) {
         unsubscriber.current();
+        unsubscriber.current = null;
       }
-      unsubscriber.current = null;
       return;
     }
 
@@ -53,7 +53,12 @@ export const useQuestionsLoader = (props: UseQuestionsLoaderProps) => {
 
     unsubscriber.current = unsubscribe;
 
-    return unsubscriber.current();
+    return () => {
+      if (unsubscriber.current) {
+        unsubscriber.current();
+        unsubscriber.current = null;
+      }
+    };
   }, [state.state, courseId]);
 
   // TODO(lnguyen2693) - handle setError


### PR DESCRIPTION
# Description

When we were exploring why our firebase reads were reaching high reads, we looked into the two Firebase snapshot locations. Now that #28 fixes the unnecessary context renders, we will still bring some of the changes for cleaner code.

React's useEffect cleanup expects a function rather than an invoke. We can cleanup and reset the unsubscribe ref. 