### PR TITLE
Show private questions in queue

### DIFF
--- a/src/app/private/course/[courseId]/board/page.tsx
+++ b/src/app/private/course/[courseId]/board/page.tsx
@@ -3,7 +3,7 @@ import Board from "@components/board";
 import Header from "@components/Header";
 import { useOfficeHour } from "@hooks/oh/useOfficeHour";
 import { Box, Button, Typography } from "@mui/material";
-import { getActiveQuestions } from "@utils/index";
+import { getActivePublicQuestion } from "@utils/index";
 import Link from "next/link";
 
 import React from "react";
@@ -17,7 +17,7 @@ interface PageProps {
 const Page = (props: PageProps) => {
   const { courseId } = props.params;
   const { questions } = useOfficeHour();
-  const activeQuestions = getActiveQuestions(questions);
+  const activeQuestions = getActivePublicQuestion(questions);
   return (
     <Box>
       <Header

--- a/src/app/utils/index.ts
+++ b/src/app/utils/index.ts
@@ -89,6 +89,13 @@ export const hasPassed = (question: IdentifiableQuestion) => {
 };
 
 export const getActiveQuestions = (
+  questions: IdentifiableQuestions
+) =>
+  questions.filter(
+    (question) => !hasPassed(question)
+  );
+
+export const getActivePublicQuestion = (
   questions: IdentifiableQuestions,
   isPublic: boolean = true
 ) =>
@@ -101,7 +108,7 @@ export const getActiveQuestionsByState = (
   isPublic: boolean = true
 ) => {
   const activeQuestions = Object.groupBy(
-    getActiveQuestions(questions, isPublic),
+    getActiveQuestions(questions),
     ({ state }) => state
   );
   return {


### PR DESCRIPTION
# Description

#### This PR fixes the following issue:
The queue doesn't display or count private questions, which can be confusing for the student if they see that it's their turn in the queue but the TAs go help other students

#### Example:
I add 5 questions to the queue:
1. Private 
2. Public
3. Public
4. Private
5. Public
--> There should be 5 questions in the queue. However, our current queue only shows 3 questions:
<img width="357" alt="Screenshot 2025-01-08 at 3 24 46 PM" src="https://github.com/user-attachments/assets/df4a2f4a-c9a0-4c8f-a0c8-23721901ccc0" />

## Test

Add 5 questions to the queue. The queue displays the private questions and the board doesn't:
<img width="356" alt="Screenshot 2025-01-08 at 3 28 31 PM" src="https://github.com/user-attachments/assets/eec01a42-b65a-42cb-8bbe-3bb1431aa533" />
<img width="356" alt="Screenshot 2025-01-08 at 3 29 00 PM" src="https://github.com/user-attachments/assets/827d85d3-a683-4b9e-83cc-6e231d0cb29e" />

