### PR TITLE
fix uncaught router push exception

### DIFF
--- a/src/app/context/UserSessionContext.tsx
+++ b/src/app/context/UserSessionContext.tsx
@@ -57,8 +57,6 @@ export const UserSessionContextProvider = ({
       } else {
         setUser(null);
         setSession({ isAuthenticated: false, isLoading: false, error: null });
-
-        router.push("/");
       }
     });
     return () => unsub();


### PR DESCRIPTION
# Description

Currently logging out gives us the error here:

![PNG image](https://github.com/user-attachments/assets/c42b4b1f-605e-4b7c-95e8-0628b41eca9c)

And this is displayed in the console:

```HTML
    "Uncaught Error: Rendered more hooks than during the previous render.
    at updateWorkInProgressHook (react-dom.development.js:11435:15)
    at updateMemo (react-dom.development.js:12613:14)
    at Object.useMemo (react-dom.development.js:13563:16)
    at useMemo (react.development.js:2537:21)
    at Router (app-router.js:232:59)
    at renderWithHooks (react-dom.development.js:11121:18)
    at updateFunctionComponent (react-dom.development.js:16290:20)
    at beginWork$1 (react-dom.development.js:18472:16)
    at HTMLUnknownElement.callCallback (react-dom.development.js:20565:14)
    at Object.invokeGuardedCallbackImpl (react-dom.development.js:20614:16)
    at invokeGuardedCallback (react-dom.development.js:20689:29)
    at beginWork (react-dom.development.js:26949:7)
    at performUnitOfWork (react-dom.development.js:25748:12)
    at workLoopSync (react-dom.development.js:25464:5)
    at renderRootSync (react-dom.development.js:25419:7)
    at recoverFromConcurrentError (react-dom.development.js:24597:20)
    at performConcurrentWorkOnRoot (react-dom.development.js:24542:26)
    at workLoop (scheduler.development.js:256:34)
    at flushWork (scheduler.development.js:225:14)
    at MessagePort.performWorkUntilDeadline (scheduler.development.js:534:21)"
```

Fixed by removing the `router.push("/")` on useEffect

## Issues

<!-- Reference the issue that you're working on (if exists) -->
<!-- When you references an issue, Github will automatically link the PR to Github -->
<!-- For example, "Resolve #1" links your PR to the first issue -->
<!-- For a full list of keywords, see here https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue -->

## Screenshots

N/A

## Test

Logged in and out on various users

## Possible Downsides

N/A

## Additional Documentations

N/A
