### PR TITLE
Unify schema for user

### DIFF
--- a/src/app/components/Sidebar.tsx
+++ b/src/app/components/Sidebar.tsx
@@ -28,7 +28,6 @@ const Sidebar = () => {
   const { user } = useUserSession();
   const router = useRouter();
 
-  console.log(user);
   React.useEffect(() => {
     const loadCourses = async () => {
       if (user && user.courses.length > 0) {

--- a/src/app/components/Sidebar.tsx
+++ b/src/app/components/Sidebar.tsx
@@ -28,6 +28,7 @@ const Sidebar = () => {
   const { user } = useUserSession();
   const router = useRouter();
 
+  console.log(user);
   React.useEffect(() => {
     const loadCourses = async () => {
       if (user && user.courses.length > 0) {

--- a/src/app/context/UserSessionContext.tsx
+++ b/src/app/context/UserSessionContext.tsx
@@ -61,6 +61,7 @@ export const UserSessionContextProvider = ({
     });
     return () => unsub();
   }, []);
+
   const onSignIn = async () => {
     try {
       await setPersistence(auth, browserLocalPersistence);

--- a/src/app/layout.tsx
+++ b/src/app/layout.tsx
@@ -20,9 +20,7 @@ export default function RootLayout({
         <div id="__next">
           <AppRouterCacheProvider>
             <UserSessionContextProvider>
-              <ThemeProviderWrapper>
-                <SidebarProvider>{children}</SidebarProvider>
-              </ThemeProviderWrapper>
+              <ThemeProviderWrapper>{children}</ThemeProviderWrapper>
             </UserSessionContextProvider>
           </AppRouterCacheProvider>
         </div>

--- a/src/app/private/layout.tsx
+++ b/src/app/private/layout.tsx
@@ -1,0 +1,11 @@
+import { SidebarProvider } from "@context/SidebarContext";
+
+interface LayoutProps {
+  children?: React.ReactNode;
+}
+
+const Layout = ({ children }: LayoutProps) => {
+  return <SidebarProvider>{children}</SidebarProvider>;
+};
+
+export default Layout;

--- a/src/app/services/firestore.ts
+++ b/src/app/services/firestore.ts
@@ -24,7 +24,12 @@ export const userConverter = {
     return user;
   },
   fromFirestore(snapshot: QueryDocumentSnapshot, options: any): User {
-    return snapshot.data(options) as User;
+    const data = snapshot.data(options) as User;
+    return {
+      ...data,
+      role: data.role ?? "user",
+      courses: data.courses ?? [],
+    };
   },
 };
 


### PR DESCRIPTION
# Description

Prior to this change, account created before #20 will not have `usernames` field in the document. As such, on first sign-in, they will see this error.

![image](https://github.com/user-attachments/assets/62fa10ae-5c36-49d6-a81e-fe5cdb35042c)
