### PR TITLE
Persist session cookies

### DIFF
--- a/src/app/api/auth/route.ts
+++ b/src/app/api/auth/route.ts
@@ -15,19 +15,14 @@ export const POST = async (request: NextRequest) => {
     const options = {
       maxAge: expiresIn,
       httpOnly: true,
-      secure: true, // Use secure cookies in production
+      secure: process.env.NODE_ENV === "production", // Use secure cookies in production
     };
 
     const response = NextResponse.json(
       { message: "Session cookie created" },
       { status: 200 }
     );
-    response.headers.set(
-      "Set-Cookie",
-      `session=${sessionCookie}; Max-Age=${
-        options.maxAge
-      }; Path=/; HttpOnly; Secure = ${process.env.NODE_ENV === "production"}`
-    );
+    response.cookies.set("session", sessionCookie, options);
     return response;
   } catch (error) {
     console.error("Error creating session cookie:", error);

--- a/src/app/api/logout/route.ts
+++ b/src/app/api/logout/route.ts
@@ -6,15 +6,7 @@ export const POST = async () => {
       { message: "Successfully logged out" },
       { status: 200 }
     );
-
-    // Remove the session cookie by setting Max-Age to 0
-    response.headers.set(
-      "Set-Cookie",
-      `session=; Max-Age=0; Path=/; HttpOnly; Secure = ${
-        process.env.NODE_ENV === "production"
-      }`
-    );
-
+    response.cookies.delete("session");
     return response;
   } catch (error) {
     console.error("Error logging out:", error);

--- a/src/app/api/session/route.ts
+++ b/src/app/api/session/route.ts
@@ -11,7 +11,9 @@ export const POST = async (request: NextRequest) => {
       { status: 200 }
     );
   } catch (error) {
-    console.log("Error verifying token:", error);
-    return NextResponse.json({ message: "Invalid token" }, { status: 500 });
+    console.log("Failed to veriy session", error);
+    const response = NextResponse.json({ message: "Reauthenticate" });
+    response.cookies.delete("session");
+    return response;
   }
 };

--- a/src/app/context/UserSessionContext.tsx
+++ b/src/app/context/UserSessionContext.tsx
@@ -108,7 +108,7 @@ export const UserSessionContextProvider = ({
       await logOutCookie();
       setUser(null);
       setSession({ isAuthenticated: false, isLoading: false, error: null });
-      router.push("/");
+      router.push("/login");
     } catch (e: any) {
       setSession({
         isAuthenticated: false,
@@ -118,6 +118,7 @@ export const UserSessionContextProvider = ({
       console.error(e);
     }
   };
+
   return session.isLoading ? (
     <Box className="flex h-screen w-screen flex-col items-center justify-center">
       <Spinner />

--- a/src/app/login/page.tsx
+++ b/src/app/login/page.tsx
@@ -9,11 +9,13 @@ import React from "react";
 export default function Page() {
   const { user, onSignIn } = useUserSession();
   const router = useRouter();
+
   React.useEffect(() => {
     if (user) {
       router.replace("/private/course");
     }
   }, [user]);
+
   if (user) {
     return (
       <Box className="flex h-screen w-screen flex-col items-center justify-center">
@@ -21,6 +23,7 @@ export default function Page() {
       </Box>
     );
   }
+
   return (
     <div className="flex items-center justify-center h-screen">
       <div className="flex flex-col items-center">

--- a/src/app/login/page.tsx
+++ b/src/app/login/page.tsx
@@ -12,7 +12,7 @@ export default function Page() {
 
   React.useEffect(() => {
     if (user) {
-      router.replace("/private/course");
+      router.push("/private/course");
     }
   }, [user]);
 

--- a/src/middleware.ts
+++ b/src/middleware.ts
@@ -4,7 +4,6 @@ export const middleware = async (request: NextRequest) => {
   const sessionCookie = request.cookies.get("session");
 
   if (!sessionCookie) {
-    console.log("Redirecting without cookig");
     return NextResponse.redirect(new URL("/login", request.url));
   }
 

--- a/src/middleware.ts
+++ b/src/middleware.ts
@@ -2,7 +2,9 @@ import { NextRequest, NextResponse } from "next/server";
 
 export const middleware = async (request: NextRequest) => {
   const sessionCookie = request.cookies.get("session");
+
   if (!sessionCookie) {
+    console.log("Redirecting without cookig");
     return NextResponse.redirect(new URL("/login", request.url));
   }
 


### PR DESCRIPTION
# Description

To be honest, I'm not quite sure what was wrong with your original approach - seems sensible if we're using Vanilla API. Also took some time to address a couple of bugs

- We should clear the cookies on signout instead of nullifying the expired time - this guarantees that the next time user log in, they won't have a valid session
- When we're trying to authenticate a session and the cookie is invalid, this is not possible to recover from right? So we should just delete it.

FYI, the [official documentation](https://firebase.google.com/docs/auth/admin/manage-cookies#sign_in) recommend that we also protect against CRSF attacks. I didn't address it in this PR since our App is not too critical.