### PR TITLE
Disable join queue for user already in the queue

### DIFF
--- a/src/app/components/queue/CreateQuestion.tsx
+++ b/src/app/components/queue/CreateQuestion.tsx
@@ -8,9 +8,15 @@ import { useOfficeHour } from "@hooks/oh/useOfficeHour";
 import React from "react";
 import { CustomModal } from "@components/CustomModal";
 import { useRouter } from "next/navigation";
+import { getQueuePosition, getUserSessionOrRedirect } from "@utils/index";
 
 const CreateQuestion = () => {
-  const { course } = useOfficeHour();
+  const { course, questions } = useOfficeHour();
+  const user = getUserSessionOrRedirect();
+  if (!user) {
+    return null;
+  }
+  const { queuePos } = getQueuePosition(questions, user);
   const [isModalVisible, setisModalVisible] = React.useState(false);
   const router = useRouter();
   const ModalButtons = [
@@ -50,6 +56,7 @@ const CreateQuestion = () => {
       text="Join queue"
       icon={<ArrowForwardOutlinedIcon />}
       onClick={() => {}}
+      disabled={queuePos !== -1}
     />
   );
   return (


### PR DESCRIPTION
# Description
- Disable `join queue` button when the user is already in the queue
## Issues
#52  

## Screenshots
- User 1 (already in queue):

<img width="335" alt="Screenshot 2025-01-25 at 12 12 03 AM" src="https://github.com/user-attachments/assets/717e9020-0cab-43eb-a618-213c3b207c9f" />

- User 2 (not in queue but join user 1's group):
<img width="332" alt="Screenshot 2025-01-25 at 12 11 37 AM" src="https://github.com/user-attachments/assets/b67a8561-0c19-4320-b3a8-0d4332952ae8" />
<img width="334" alt="Screenshot 2025-01-25 at 12 11 46 AM" src="https://github.com/user-attachments/assets/77733118-f232-470b-a26d-52b8ebe6cff4" />

<!-- If you're making UI changes, please include screenshots and describe the expected user flow. -->

## Test
- Use account_1 to join the queue and check `join queue` button
- Use account_2 to join account_1's question group , check account_2's `join queue` button to make sure it's not disabled
