### PR TITLE
Sidebar resizing and functionalities

### DIFF
--- a/src/app/components/Sidebar.tsx
+++ b/src/app/components/Sidebar.tsx
@@ -35,8 +35,8 @@ const Sidebar = () => {
   React.useEffect(() => {
     const loadCourses = async () => {
       if (user && user.courses.length > 0) {
-        const courses = await getCoursesByIds(user.courses);
-        setCourses(courses);
+        const fetchCourses = await getCoursesByIds(user.courses);
+        setCourses(fetchCourses);
       } else {
         setCourses([]);
       }

--- a/src/app/components/Sidebar.tsx
+++ b/src/app/components/Sidebar.tsx
@@ -152,17 +152,15 @@ const Sidebar = () => {
           <Box
             sx={{
               display: "flex",
-              flexDirection: "row",
+              flexDirection: { xs: "column", sm: "row" },
               justifyContent: "space-between",
-              alignItems: "center",
             }}
           >
             <Box
               sx={{
                 display: "flex",
                 flexDirection: "row",
-                justifyContent: "space-between",
-                alignItems: "flex-end",
+                alignItems: "center",
                 gap: "12px",
               }}
             >
@@ -175,11 +173,11 @@ const Sidebar = () => {
               >
                 {user ? user.name[0] : ""}
               </Avatar>
-              <Box>
+              <Box width="100%" overflow="scroll">
                 <Typography variant="subtitle1">
                   {trimUserName(user)}
                 </Typography>
-                <Typography variant="caption">
+                <Typography variant="caption" noWrap>
                   {user ? user.email : ""}
                 </Typography>
               </Box>
@@ -188,8 +186,9 @@ const Sidebar = () => {
               sx={{
                 textTransform: "none",
                 color: "inherit",
-                justifyContent: "flex-start",
+                justifyContent: "flex-end",
                 gap: "8px",
+                marginTop: { xs: "24px", sm: "0px" },
               }}
               onClick={onSignOut}
             >

--- a/src/app/components/Sidebar.tsx
+++ b/src/app/components/Sidebar.tsx
@@ -82,27 +82,30 @@ const Sidebar = () => {
           flexDirection: "column",
           padding: "30px 30px 0",
           height: "100vh",
+          overflow: "hidden",
         }}
       >
         <Box
           sx={{
             display: "flex",
-            flexDirection: "column",
+            flexDirection: "row",
+            justifyContent: "space-between",
+            alignItems: "center",
           }}
         >
-          <Box
-            sx={{
-              display: "flex",
-              flexDirection: "row",
-              justifyContent: "space-between",
-              alignItems: "center",
-            }}
-          >
-            <Typography variant="h6" color={theme.palette.text.primary}>
-              My Classes
-            </Typography>
-            <MenuButton isOpen={false} />
-          </Box>
+          <Typography variant="h6" color={theme.palette.text.primary}>
+            My Classes
+          </Typography>
+          <MenuButton isOpen={false} />
+        </Box>
+        <Box
+          sx={{
+            display: "flex",
+            flexDirection: "column",
+            height: "100%",
+            overflowY: "scroll",
+          }}
+        >
           <List>
             {courses.map((course, index) => (
               <ListItemButton
@@ -123,21 +126,21 @@ const Sidebar = () => {
               </ListItemButton>
             ))}
           </List>
+          <Divider sx={{ marginBottom: "12px" }} />
+          <Button
+            sx={{
+              justifyContent: "flex-start",
+              gap: "8px",
+              textTransform: "none",
+              color: "inherit",
+              marginBottom: "12px",
+            }}
+            onClick={handleManageCoursesClick}
+          >
+            <ModeEditOutlinedIcon />
+            <Typography variant="body1">Manage Classes</Typography>
+          </Button>
         </Box>
-        <Divider sx={{ marginBottom: "12px" }} />
-
-        <Button
-          sx={{
-            justifyContent: "flex-start",
-            gap: "8px",
-            textTransform: "none",
-            color: "inherit",
-          }}
-          onClick={handleManageCoursesClick}
-        >
-          <ModeEditOutlinedIcon />
-          <Typography variant="body1">Manage Classes</Typography>
-        </Button>
 
         <Box
           sx={{
@@ -177,7 +180,7 @@ const Sidebar = () => {
                 <Typography variant="subtitle1">
                   {trimUserName(user)}
                 </Typography>
-                <Typography variant="caption" noWrap>
+                <Typography variant="caption">
                   {user ? user.email : ""}
                 </Typography>
               </Box>

--- a/src/app/components/Sidebar.tsx
+++ b/src/app/components/Sidebar.tsx
@@ -73,7 +73,7 @@ const Sidebar = () => {
       onClose={closeSidebar}
       variant="temporary"
       sx={{
-        "& .MuiDrawer-paper": { width: "100%" },
+        "& .MuiDrawer-paper": { width: "80%" },
       }}
     >
       <Box

--- a/src/app/components/Sidebar.tsx
+++ b/src/app/components/Sidebar.tsx
@@ -73,7 +73,7 @@ const Sidebar = () => {
       onClose={closeSidebar}
       variant="temporary"
       sx={{
-        "& .MuiDrawer-paper": { width: "80%" },
+        "& .MuiDrawer-paper": { width: "70%" },
       }}
     >
       <Box


### PR DESCRIPTION
# Description

- Resized sidebar to 70%
- Rearranged logout button and avatar section to handle smaller screens without overflowing
- Handled overflow of user email in avatar section
- Handled overflow of classes

## Issues

#49 

## Screenshots

<img width="351" alt="image" src="https://github.com/user-attachments/assets/9d52fe7a-2686-42d4-a44f-f1d5b92cfe43" />

<img width="345" alt="image" src="https://github.com/user-attachments/assets/1f18ee0f-bdee-4e10-b1bf-6aeb82970246" />


## Test

Tested adding a bunch of classes and a bunch of different screens.

## Possible Downsides

Tried different alignment of Manage Classes (start, end, center) and it doesn't fit too well on 70% on smallest screen so ended up leaving it as center. Let me know though what yall think!

## Additional Documentations

None!
