### PR TITLE
Board page hamburger menu & cleanup

### DIFF
--- a/src/app/components/Header.tsx
+++ b/src/app/components/Header.tsx
@@ -5,7 +5,6 @@ interface IHeader {
   leftIcon?: React.ReactNode;
   title?: string;
   rightIcon?: React.ReactNode;
-  alignCenter?: boolean;
 }
 
 const Header = (props: IHeader) => {

--- a/src/app/components/Header.tsx
+++ b/src/app/components/Header.tsx
@@ -9,21 +9,38 @@ interface IHeader {
 }
 
 const Header = (props: IHeader) => {
-  const { title, leftIcon, rightIcon, alignCenter } = props;
+  const { title, leftIcon, rightIcon } = props;
+
   return (
     <AppBar position="static" elevation={0} color="inherit">
-      <Toolbar disableGutters sx={{ marginLeft: "1%" }}>
-        {leftIcon}
-        <Typography
-          variant="h6"
-          component="div"
-          className={`flex-grow ${alignCenter ? "text-center" : "text-start"}`}
-          sx={{ fontWeight: 400, marginLeft: alignCenter ? "0" : "5%" }}
+      <Toolbar
+        disableGutters
+        sx={{
+          marginX: "1%",
+          justifyContent: "space-between",
+        }}
+      >
+        <Box
+          display="flex"
+          flexDirection="row"
+          alignItems="center"
+          width="100%"
         >
-          {title}
-        </Typography>
+          {leftIcon}
+          {rightIcon ? (
+            <Box display="flex" alignItems="center">
+              <Typography variant="h6" textAlign="left">
+                {title}
+              </Typography>
+            </Box>
+          ) : (
+            <Typography variant="h6" textAlign="center" flexGrow={1}>
+              {title}
+            </Typography>
+          )}
+        </Box>
 
-        {alignCenter && !rightIcon ? <Box className="w-[40px]" /> : rightIcon}
+        {!rightIcon ? <Box width="32px" /> : rightIcon}
       </Toolbar>
     </AppBar>
   );

--- a/src/app/components/board/index.tsx
+++ b/src/app/components/board/index.tsx
@@ -88,7 +88,10 @@ const Board = (props: BoardProps) => {
       <ToggleButtonGroup
         value={selectedTopics}
         onChange={addOrRemoveTopic}
-        fullWidth
+        sx={{
+          overflowX: "scroll",
+          width: "calc(100% + 16px)",
+        }}
       >
         <Stack
           columnGap="8px"

--- a/src/app/components/board/index.tsx
+++ b/src/app/components/board/index.tsx
@@ -99,6 +99,7 @@ const Board = (props: BoardProps) => {
           overflow="auto"
           paddingBottom="16px"
           marginBottom="16px"
+          paddingRight="16px"
         >
           {topics.map((topic) => (
             <ToggleButton

--- a/src/app/components/queue/CreateQuestion.tsx
+++ b/src/app/components/queue/CreateQuestion.tsx
@@ -8,11 +8,12 @@ import { useOfficeHour } from "@hooks/oh/useOfficeHour";
 import React from "react";
 import { CustomModal } from "@components/CustomModal";
 import { useRouter } from "next/navigation";
-import { getQueuePosition, getUserSessionOrRedirect } from "@utils/index";
+import { getQueuePosition } from "@utils/index";
+import { useUserOrRedirect } from "@hooks/useUserOrRedirect";
 
 const CreateQuestion = () => {
   const { course, questions } = useOfficeHour();
-  const user = getUserSessionOrRedirect();
+  const user = useUserOrRedirect();
   if (!user) {
     return null;
   }

--- a/src/app/private/course/[courseId]/board/page.tsx
+++ b/src/app/private/course/[courseId]/board/page.tsx
@@ -1,6 +1,7 @@
 "use client";
 
 import Board from "@components/board";
+import MenuButton from "@components/buttons/MenuButton";
 import Header from "@components/Header";
 import { useOfficeHour } from "@hooks/oh/useOfficeHour";
 import { useUserOrRedirect } from "@hooks/useUserOrRedirect";
@@ -30,13 +31,16 @@ const Page = (props: PageProps) => {
   return (
     <Box>
       <Header
-        title="Board"
+        title="Public Board"
+        leftIcon={<MenuButton isEdge />}
         rightIcon={
           <Link href={`/private/course/${courseId}/board/history`}>
             <Button
               style={{
                 textTransform: "none",
                 padding: 0,
+                width: "100px",
+                justifyContent: "end",
               }}
             >
               <Typography variant="subtitle2">

--- a/src/app/private/course/[courseId]/page.tsx
+++ b/src/app/private/course/[courseId]/page.tsx
@@ -46,11 +46,7 @@ const Page = (props: PageProps) => {
   const isUserTA = course.tas.includes(user.id);
   return (
     <div>
-      <Header
-        leftIcon={<MenuButton isEdge />}
-        title={courseId.toUpperCase()}
-        alignCenter
-      />
+      <Header leftIcon={<MenuButton isEdge />} title={courseId.toUpperCase()} />
       {isUserTA ? (
         <TADisplayCourse tas={tas} students={students} />
       ) : (

--- a/src/app/private/course/[courseId]/profile/page.tsx
+++ b/src/app/private/course/[courseId]/profile/page.tsx
@@ -33,11 +33,7 @@ const Page = (props: PageProps) => {
 
   return (
     <div>
-      <Header
-        leftIcon={<MenuButton isEdge />}
-        title={courseId.toUpperCase()}
-        alignCenter
-      />
+      <Header leftIcon={<MenuButton isEdge />} title={courseId.toUpperCase()} />
       <div className="flex items-center gap-4">
         <Avatar
           sx={{ bgcolor: theme.palette.primary.main, height: 56, width: 56 }}

--- a/src/app/private/course/[courseId]/queue/page.tsx
+++ b/src/app/private/course/[courseId]/queue/page.tsx
@@ -86,11 +86,7 @@ const Page = () => {
       position="relative"
       paddingBottom="112px"
     >
-      <Header
-        leftIcon={<MenuButton isEdge />}
-        title={course.name}
-        alignCenter
-      />
+      <Header leftIcon={<MenuButton isEdge />} title={course.name} />
       {!helpingQuestion ? (
         <>
           {isUserTA ? (


### PR DESCRIPTION
# Description

Added hamburger menu to board page, changed name to Public Board, and made tags expand full screen:

- Reworked logic to handle alignment based on rightIcon existence
- Cleaned up unnecessary styles and props
- Fixed bug in mismatched userSessionRedirect

## Issues

#50 
#53 

## Screenshots

<img width="357" alt="image" src="https://github.com/user-attachments/assets/dcb08775-e6b1-468e-81d5-09b064479530" />

<img width="350" alt="image" src="https://github.com/user-attachments/assets/b6977d16-3426-4262-a335-91021450385f" />


## Test

Compared current prod website styling with local, tested hamburger menu navigation, and matched to Figma

## Possible Downsides

None!

## Additional Documentations

None!
