### PR TITLE
Sidebar, Course Join Page, Public Questions

### DIFF
--- a/src/app/components/AnnouncementTile.tsx
+++ b/src/app/components/AnnouncementTile.tsx
@@ -12,6 +12,7 @@ import { useOfficeHour } from "@hooks/oh/useOfficeHour";
 import { Announcement } from "@interfaces/db";
 import { CustomModal } from "./CustomModal";
 import UndoIcon from "@mui/icons-material/Undo";
+import { RoundedTile } from "./RoundedTile";
 interface AnnouncementTileProps {
   announcement: Announcement;
   isEdit: boolean;
@@ -29,7 +30,7 @@ export const AnnouncementTile = (props: AnnouncementTileProps) => {
   );
   const [deleteVisible, setDeleteVisible] = React.useState<boolean>(false);
   const [error, setError] = React.useState<string>("");
-  
+
   React.useEffect(() => {
     if (!isEdit) {
       setNewMessage(announcement.message);
@@ -131,13 +132,7 @@ export const AnnouncementTile = (props: AnnouncementTileProps) => {
       </Button>
     </Box>
   ) : (
-    <Box
-      sx={{
-        padding: "16px 16px",
-        bgcolor: "#F8F9FF",
-        borderRadius: "16px",
-      }}
-    >
+    <RoundedTile>
       <Typography
         variant="body2"
         color={theme.palette.text.secondary}
@@ -145,7 +140,6 @@ export const AnnouncementTile = (props: AnnouncementTileProps) => {
       >
         {announcement.message}
       </Typography>
-
       {isEdit && (
         <Box sx={{ display: "flex", justifyContent: "flex-end" }}>
           <CustomModal
@@ -177,6 +171,6 @@ export const AnnouncementTile = (props: AnnouncementTileProps) => {
           </Box>
         </Box>
       )}
-    </Box>
+    </RoundedTile>
   );
 };

--- a/src/app/components/CourseCard.tsx
+++ b/src/app/components/CourseCard.tsx
@@ -1,0 +1,34 @@
+import { IdentifiableCourse } from "@interfaces/type";
+import { Box, Typography } from "@mui/material";
+import { useRouter } from "next/navigation";
+interface CourseCardProps {
+  course: IdentifiableCourse;
+}
+export const CourseCard = (props: CourseCardProps) => {
+  const { course } = props;
+  const router = useRouter();
+  return (
+    <Box
+      className="flex items-center justify-between px-4 w-full"
+      onClick={() => router.push(`/private/course/${course.id}`)}
+    >
+      <Box
+        className="flex flex-col w-full p-4"
+        sx={{
+          backgroundColor: "#f8f9ff",
+          borderRadius: "12px",
+          borderColor: "#c2c6cf",
+          borderWidth: "1px",
+          borderStyle: "solid",
+        }}
+      >
+        <Typography variant="h6">
+          {course.id.toUpperCase() + " " + course.name}
+        </Typography>
+        <Typography variant="subtitle1" color="#43474E">
+          {course.professors.join(", ")}
+        </Typography>
+      </Box>
+    </Box>
+  );
+};

--- a/src/app/components/CourseCard.tsx
+++ b/src/app/components/CourseCard.tsx
@@ -9,7 +9,7 @@ export const CourseCard = (props: CourseCardProps) => {
   const router = useRouter();
   return (
     <Box
-      className="flex items-center justify-between px-4 w-full"
+      className="flex items-center justify-between px-4 w-full cursor-pointer"
       onClick={() => router.push(`/private/course/${course.id}`)}
     >
       <Box

--- a/src/app/components/DisplayLocHours.tsx
+++ b/src/app/components/DisplayLocHours.tsx
@@ -1,0 +1,105 @@
+"use client";
+import { useOfficeHour } from "@hooks/oh/useOfficeHour";
+import { Box, Button, TextField, Typography } from "@mui/material";
+import { partialUpdateCourse } from "@services/client/course";
+import React from "react";
+import theme from "theme";
+
+interface DisplayLocHoursProps {
+  location: string;
+  editable?: boolean;
+}
+
+const renderWithLinks = (text: string) => {
+  const urlRegex = /(https?:\/\/[^\s]+|www\.[^\s]+)/g;
+
+  const parts = text.split(urlRegex);
+  return parts.map((part, index) => {
+    if (urlRegex.test(part)) {
+      const href = part.startsWith("http") ? part : `https://${part}`;
+      return (
+        <a
+          key={index}
+          href={href}
+          target="_blank"
+          rel="noopener noreferrer"
+          style={{ color: "#38608F", textDecoration: "underline" }}
+        >
+          {part}
+        </a>
+      );
+    }
+    return part;
+  });
+};
+
+export const DisplayLocHours = (props: DisplayLocHoursProps) => {
+  const { location, editable = false } = props;
+  const [isEdit, setIsEdit] = React.useState<boolean>(false);
+  const [currLocation, setCurrLocation] = React.useState<string>(location);
+  const [error, setError] = React.useState<string>("");
+  const { course } = useOfficeHour();
+
+  React.useEffect(() => {
+    setCurrLocation(location);
+  }, [location]);
+
+  const onEditDone = async () => {
+    if (isEdit && currLocation.trim() === "") {
+      setError("Location & Hours cannot be empty");
+      return;
+    }
+
+    if (isEdit && currLocation.trim() !== location) {
+      await partialUpdateCourse(course.id, { location: currLocation.trim() });
+    }
+    setIsEdit(!isEdit);
+  };
+
+  return (
+    <Box>
+      <Box className="flex flex-row justify-between">
+        <Typography
+          variant="h6"
+          color={theme.palette.text.primary}
+          sx={{ fontWeight: "bold" }}
+        >
+          Location & Hours
+        </Typography>
+        {editable && (
+          <Button onClick={onEditDone} sx={{ textTransform: "none" }}>
+            <Typography color={"#38608F"} variant="subtitle2">
+              {isEdit ? "Save" : "Edit"}
+            </Typography>
+          </Button>
+        )}
+      </Box>
+      <Box
+        sx={{
+          padding: "16px 16px",
+          gap: "10px",
+          flexDirection: "column",
+          display: "flex",
+          marginTop: "16px",
+        }}
+      >
+        {isEdit ? (
+          <TextField
+            focused
+            multiline
+            label="Location & Hours"
+            fullWidth
+            defaultValue={currLocation}
+            onChange={(e) => setCurrLocation(e.target.value)}
+            error={error !== ""}
+            helperText={error}
+          />
+        ) : (
+          <Typography variant="body2" color={theme.palette.text.primary}>
+            {renderWithLinks(currLocation)}
+          </Typography>
+        )}
+      </Box>
+    </Box>
+  );
+};

--- a/src/app/components/DisplayLocHours.tsx
+++ b/src/app/components/DisplayLocHours.tsx
@@ -4,6 +4,7 @@ import { Box, Button, TextField, Typography } from "@mui/material";
 import { partialUpdateCourse } from "@services/client/course";
 import React from "react";
 import theme from "theme";
+import { RoundedTile } from "./RoundedTile";
 
 interface DisplayLocHoursProps {
   location: string;
@@ -74,15 +75,7 @@ export const DisplayLocHours = (props: DisplayLocHoursProps) => {
           </Button>
         )}
       </Box>
-      <Box
-        sx={{
-          padding: "16px 16px",
-          gap: "10px",
-          flexDirection: "column",
-          display: "flex",
-          marginTop: "16px",
-        }}
-      >
+      <RoundedTile>
         {isEdit ? (
           <TextField
             focused
@@ -95,11 +88,15 @@ export const DisplayLocHours = (props: DisplayLocHoursProps) => {
             helperText={error}
           />
         ) : (
-          <Typography variant="body2" color={theme.palette.text.primary}>
+          <Typography
+            variant="body2"
+            color={theme.palette.text.secondary}
+            sx={{ whiteSpace: "pre-line" }}
+          >
             {renderWithLinks(currLocation)}
           </Typography>
         )}
-      </Box>
+      </RoundedTile>
     </Box>
   );
 };

--- a/src/app/components/DisplayLocHours.tsx
+++ b/src/app/components/DisplayLocHours.tsx
@@ -1,11 +1,11 @@
 "use client";
 import { useOfficeHour } from "@hooks/oh/useOfficeHour";
-import { Box, Button, TextField, Typography } from "@mui/material";
+import { Box, Button, IconButton, TextField, Typography } from "@mui/material";
 import { partialUpdateCourse } from "@services/client/course";
 import React from "react";
 import theme from "theme";
 import { RoundedTile } from "./RoundedTile";
-
+import UndoIcon from "@mui/icons-material/Undo";
 interface DisplayLocHoursProps {
   location: string;
   editable?: boolean;
@@ -46,15 +46,25 @@ export const DisplayLocHours = (props: DisplayLocHoursProps) => {
   }, [location]);
 
   const onEditDone = async () => {
-    if (isEdit && currLocation.trim() === "") {
-      setError("Location & Hours cannot be empty");
-      return;
+    const trimmedCurrLocation = currLocation.trim();
+
+    if (isEdit) {
+      if (trimmedCurrLocation === "") {
+        setError("Location & Hours cannot be empty");
+        return;
+      } else if (trimmedCurrLocation !== location) {
+        await partialUpdateCourse(course.id, { location: trimmedCurrLocation });
+      }
+      setError("");
     }
 
-    if (isEdit && currLocation.trim() !== location) {
-      await partialUpdateCourse(course.id, { location: currLocation.trim() });
-    }
     setIsEdit(!isEdit);
+  };
+
+  const onUndo = () => {
+    setCurrLocation(currLocation);
+    setError("");
+    setIsEdit(false);
   };
 
   return (
@@ -77,16 +87,30 @@ export const DisplayLocHours = (props: DisplayLocHoursProps) => {
       </Box>
       <RoundedTile>
         {isEdit ? (
-          <TextField
-            focused
-            multiline
-            label="Location & Hours"
-            fullWidth
-            defaultValue={currLocation}
-            onChange={(e) => setCurrLocation(e.target.value)}
-            error={error !== ""}
-            helperText={error}
-          />
+          <Box sx={{ position: "relative", width: "100%" }}>
+            <TextField
+              focused
+              multiline
+              label="Location & Hours"
+              fullWidth
+              defaultValue={currLocation}
+              onChange={(e) => setCurrLocation(e.target.value)}
+              error={error !== ""}
+              helperText={error}
+            />
+            <IconButton
+              sx={{
+                position: "absolute",
+                bottom: error ? 30 : 10,
+                right: 10,
+                gap: "4px",
+              }}
+              onClick={onUndo}
+            >
+              <UndoIcon fontSize="small" />
+              <Typography variant="caption">Undo</Typography>
+            </IconButton>
+          </Box>
         ) : (
           <Typography
             variant="body2"

--- a/src/app/components/DisplayLocHours.tsx
+++ b/src/app/components/DisplayLocHours.tsx
@@ -64,6 +64,7 @@ export const DisplayLocHours = (props: DisplayLocHoursProps) => {
   const onUndo = () => {
     setCurrLocation(location);
     setError("");
+    setIsEdit(false);
   };
 
   return (

--- a/src/app/components/DisplayLocHours.tsx
+++ b/src/app/components/DisplayLocHours.tsx
@@ -62,9 +62,8 @@ export const DisplayLocHours = (props: DisplayLocHoursProps) => {
   };
 
   const onUndo = () => {
-    setCurrLocation(currLocation);
+    setCurrLocation(location);
     setError("");
-    setIsEdit(false);
   };
 
   return (
@@ -93,7 +92,7 @@ export const DisplayLocHours = (props: DisplayLocHoursProps) => {
               multiline
               label="Location & Hours"
               fullWidth
-              defaultValue={currLocation}
+              value={currLocation}
               onChange={(e) => setCurrLocation(e.target.value)}
               error={error !== ""}
               helperText={error}

--- a/src/app/components/EnrolledCourses.tsx
+++ b/src/app/components/EnrolledCourses.tsx
@@ -52,7 +52,7 @@ export const EnrolledCourses = () => {
             ))}
             <Button
               variant="contained"
-              className="py-2.5 px-6 rounded-full normal-case"
+              className="py-2.5 px-6 rounded-full normal-case my-4"
               onClick={() => router.push("/private/course/join")}
             >
               <Typography variant="subtitle2" color="#FFFFFF" fontWeight={600}>

--- a/src/app/components/EnrolledCourses.tsx
+++ b/src/app/components/EnrolledCourses.tsx
@@ -1,0 +1,82 @@
+"use client";
+
+import { useUserOrRedirect } from "@hooks/useUserOrRedirect";
+import { IdentifiableCourses } from "@interfaces/type";
+import { useRouter } from "next/navigation";
+import Header from "./Header";
+import MenuButton from "./buttons/MenuButton";
+import { Box, Button, IconButton, Typography } from "@mui/material";
+import React from "react";
+import { getUserCourses } from "@services/client/course";
+import { CourseCard } from "./CourseCard";
+import Spinner from "./Spinner";
+
+export const EnrolledCourses = () => {
+  const router = useRouter();
+  const user = useUserOrRedirect();
+  const [courses, setCourses] = React.useState<IdentifiableCourses>([]);
+  const [fetching, setFetching] = React.useState(true);
+
+  React.useEffect(() => {
+    const fetchCourses = async () => {
+      if (user && user.courses.length > 0) {
+        setFetching(true);
+        const fetchedCourses = await getUserCourses(user);
+        setCourses(fetchedCourses);
+      }
+      setFetching(false);
+    };
+    fetchCourses();
+  }, [user]);
+
+  if (!user || fetching) {
+    return (
+      <Box className="flex flex-col h-screen items-center justify-center">
+        <Spinner width={64} height={64} />;
+      </Box>
+    );
+  }
+
+  return (
+    <Box className="flex flex-col h-screen">
+      <Header
+        leftIcon={<MenuButton />}
+        title="Enrolled Classes"
+        rightIcon={<IconButton />}
+      />
+      <Box className="flex flex-col justify-center items-center">
+        {courses.length > 0 ? (
+          <Box className="flex flex-col gap-4 w-full mt-4 items-center">
+            {courses.map((course) => (
+              <CourseCard key={course.id} course={course} />
+            ))}
+            <Button
+              variant="contained"
+              className="py-2.5 px-6 rounded-full normal-case"
+              onClick={() => router.push("/private/course/join")}
+            >
+              <Typography variant="subtitle2" color="#FFFFFF" fontWeight={600}>
+                Join class
+              </Typography>
+            </Button>
+          </Box>
+        ) : (
+          <Box className="flex flex-col justify-center items-center gap-4 h-[90vh]">
+            <Typography variant="subtitle1">
+              Add a class to get started
+            </Typography>
+            <Button
+              variant="contained"
+              className="py-2.5 px-6 rounded-full normal-case"
+              onClick={() => router.push("/private/course/join")}
+            >
+              <Typography variant="subtitle2" color="#FFFFFF" fontWeight={600}>
+                Join class
+              </Typography>
+            </Button>
+          </Box>
+        )}
+      </Box>
+    </Box>
+  );
+};

--- a/src/app/components/RoundedTile.tsx
+++ b/src/app/components/RoundedTile.tsx
@@ -1,0 +1,20 @@
+import { Box } from "@mui/material";
+
+interface RoundedTileProps {
+  children?: React.ReactNode;
+}
+
+export const RoundedTile = (props: RoundedTileProps) => {
+  const { children } = props;
+  return (
+    <Box
+      sx={{
+        padding: "16px 16px",
+        bgcolor: "#F8F9FF",
+        borderRadius: "16px",
+      }}
+    >
+      {children}
+    </Box>
+  );
+};

--- a/src/app/components/Sidebar.tsx
+++ b/src/app/components/Sidebar.tsx
@@ -53,7 +53,7 @@ const Sidebar = () => {
 
   const handleManageCoursesClick = () => {
     if (courses.length > 0) {
-      router.push(`/private/course/${courses[0].id}/profile/edit`);
+      router.push(`/private/course/${courses[0].id}/profile/`);
     } else {
       router.push(`/private/course`);
     }
@@ -98,7 +98,7 @@ const Sidebar = () => {
           <Typography variant="h6" color={theme.palette.text.primary}>
             My Classes
           </Typography>
-          <MenuButton isOpen={false} />
+          {!isOpen && <MenuButton isOpen={false} />}
         </Box>
         <Box
           sx={{
@@ -113,7 +113,7 @@ const Sidebar = () => {
               <ListItemButton
                 key={index}
                 sx={{
-                  padding: "16px 12px",
+                  padding: "8px 12px",
                   borderRadius: "9999px",
                   "&:active": {
                     backgroundColor: theme.palette.primary.main,
@@ -191,7 +191,7 @@ const Sidebar = () => {
               sx={{
                 textTransform: "none",
                 color: "inherit",
-                justifyContent: "flex-end",
+                justifyContent: "flex-start",
                 gap: "8px",
                 marginTop: { xs: "24px", sm: "0px" },
               }}

--- a/src/app/components/Sidebar.tsx
+++ b/src/app/components/Sidebar.tsx
@@ -94,7 +94,6 @@ const Sidebar = () => {
           <Typography variant="h6" color={theme.palette.text.primary}>
             My Classes
           </Typography>
-          {!isOpen && <MenuButton isOpen={false} />}
         </Box>
         <Box
           sx={{

--- a/src/app/components/Sidebar.tsx
+++ b/src/app/components/Sidebar.tsx
@@ -52,11 +52,7 @@ const Sidebar = () => {
   };
 
   const handleManageCoursesClick = () => {
-    if (courses.length > 0) {
-      router.push(`/private/course/${courses[0].id}/profile/`);
-    } else {
-      router.push(`/private/course`);
-    }
+    router.push(`/private/course`);
     closeSidebar();
   };
 

--- a/src/app/components/StudentDisplayCourse.tsx
+++ b/src/app/components/StudentDisplayCourse.tsx
@@ -6,6 +6,7 @@ import { IdentifiableUsers } from "@interfaces/type";
 import { usePathname, useRouter } from "next/navigation";
 import { useOfficeHour } from "@hooks/oh/useOfficeHour";
 import { DisplayAnnouncements } from "./DisplayAnnouncements";
+import { DisplayLocHours } from "./DisplayLocHours";
 
 interface StudentDisplayCourseProps {
   tas: IdentifiableUsers;
@@ -31,31 +32,7 @@ const StudentDisplayCourse = (props: StudentDisplayCourseProps) => {
         announcements={course.announcements}
         editable={false}
       />
-      <Box>
-        <Typography
-          variant="h6"
-          color={theme.palette.text.primary}
-          sx={{ fontWeight: "bold" }}
-        >
-          Location & Hours
-        </Typography>
-        <Box
-          sx={{
-            padding: "16px 16px",
-            gap: "10px",
-            flexDirection: "column",
-            display: "flex",
-            marginTop: "16px",
-          }}
-        >
-          <Typography variant="body2" color={theme.palette.text.primary}>
-            JCC 4th floor huddle room
-          </Typography>
-          <Typography variant="body2" color={theme.palette.text.primary}>
-            6 - 9 PM
-          </Typography>
-        </Box>
-      </Box>
+      <DisplayLocHours location={course.location} editable={false} />
       <Box sx={{ display: "flex", flexDirection: "column", gap: "10px" }}>
         <Box
           sx={{

--- a/src/app/components/TADisplayCourse.tsx
+++ b/src/app/components/TADisplayCourse.tsx
@@ -7,6 +7,7 @@ import { usePathname, useRouter } from "next/navigation";
 import { useOfficeHour } from "@hooks/oh/useOfficeHour";
 import { DisplayAnnouncements } from "./DisplayAnnouncements";
 import React from "react";
+import { DisplayLocHours } from "./DisplayLocHours";
 
 interface TADisplayCourseProps {
   tas: IdentifiableUsers;
@@ -18,7 +19,6 @@ const TADisplayCourse = (props: TADisplayCourseProps) => {
   const router = useRouter();
   const pathname = usePathname();
   const { course } = useOfficeHour();
-  
   return (
     <Box
       sx={{
@@ -29,31 +29,7 @@ const TADisplayCourse = (props: TADisplayCourseProps) => {
       }}
     >
       <DisplayAnnouncements announcements={course.announcements} editable />
-      <Box>
-        <Typography
-          variant="h6"
-          color={theme.palette.text.primary}
-          sx={{ fontWeight: "bold" }}
-        >
-          Location & Hours
-        </Typography>
-        <Box
-          sx={{
-            padding: "16px 16px",
-            gap: "10px",
-            flexDirection: "column",
-            display: "flex",
-            marginTop: "16px",
-          }}
-        >
-          <Typography variant="body2" color={theme.palette.text.primary}>
-            JCC 4th floor huddle room
-          </Typography>
-          <Typography variant="body2" color={theme.palette.text.primary}>
-            6 - 9 PM
-          </Typography>
-        </Box>
-      </Box>
+      <DisplayLocHours location={course.location} editable />
       <Box
         sx={{
           display: "flex",

--- a/src/app/components/board/Question.tsx
+++ b/src/app/components/board/Question.tsx
@@ -3,7 +3,7 @@ import Spinner from "@components/Spinner";
 import { useUserOrRedirect } from "@hooks/useUserOrRedirect";
 import { QuestionState } from "@interfaces/db";
 import { IdentifiableQuestion, IdentifiableUsers } from "@interfaces/type";
-import { Avatar, Box, Typography } from "@mui/material";
+import { Avatar, Box, Link, Typography } from "@mui/material";
 import { getUsers } from "@services/client/user";
 import { formatTimeDifference, hasPassed, trimUserName } from "@utils/index";
 import { useRouter } from "next/navigation";
@@ -43,120 +43,121 @@ const Question = (props: QuestionProps) => {
       <Spinner />
     </div>
   ) : (
-    <Box
-      sx={{
-        backgroundColor: "#F2F3FA",
-        outlineColor: beingHelped ? theme.palette.primary.main : null,
-        outlineStyle: beingHelped ? "solid" : null,
-        outlineWidth: "2px",
-      }}
-      padding="16px"
-      borderRadius="8px"
-    >
+    <Link href={`${window.location.pathname}/${question.id}`} underline="none">
       <Box
-        height="48px"
-        display="flex"
-        flexDirection="row"
-        gap="16px"
-        alignItems="center"
+        sx={{
+          backgroundColor: "#F2F3FA",
+          outlineColor: beingHelped ? theme.palette.primary.main : null,
+          outlineStyle: beingHelped ? "solid" : null,
+          outlineWidth: "2px",
+        }}
+        padding="16px"
+        borderRadius="8px"
       >
-        <Avatar sx={{ bgcolor: theme.palette.primary.main }}>
-          {trimUserName(users[0])[0]}
-        </Avatar>
-        <Box>
+        <Box
+          height="48px"
+          display="flex"
+          flexDirection="row"
+          gap="16px"
+          alignItems="center"
+        >
+          <Avatar sx={{ bgcolor: theme.palette.primary.main }}>
+            {trimUserName(users[0])[0]}
+          </Avatar>
+          <Box>
+            <Typography
+              style={{
+                fontSize: 18,
+                fontWeight: "bold",
+                color: "#191C20",
+                textOverflow: "ellipsis",
+                overflow: "hidden",
+              }}
+            >
+              {trimUserName(users[0])}
+            </Typography>
+            <Typography
+              style={{
+                fontSize: 14,
+                color: "#43474E",
+                textOverflow: "ellipsis",
+                overflow: "hidden",
+              }}
+            >
+              {formatTimeDifference(question)}
+            </Typography>
+          </Box>
+        </Box>
+
+        <Box marginTop="28px" fontWeight={400}>
           <Typography
             style={{
-              fontSize: 18,
-              fontWeight: "bold",
+              fontSize: 16,
               color: "#191C20",
               textOverflow: "ellipsis",
               overflow: "hidden",
+              fontWeight: 500,
             }}
           >
-            {trimUserName(users[0])}
+            {question.title}
           </Typography>
           <Typography
             style={{
-              fontSize: 14,
+              fontSize: "14px",
+              marginTop: "8px",
               color: "#43474E",
               textOverflow: "ellipsis",
               overflow: "hidden",
             }}
           >
-            {formatTimeDifference(question)}
+            {question.description}
           </Typography>
         </Box>
-      </Box>
-
-      <Box marginTop="28px" fontWeight={400}>
-        <Typography
-          style={{
-            fontSize: 16,
-            color: "#191C20",
-            textOverflow: "ellipsis",
-            overflow: "hidden",
-            fontWeight: 500,
-          }}
+        <Box marginTop="32px">
+          <Box display="flex" columnGap="16px" rowGap="8px" flexWrap="wrap">
+            {question.tags.map((tag) => (
+              <Box
+                key={tag.choice}
+                border={1}
+                borderColor="#73777F"
+                borderRadius="10px"
+                paddingY="4px"
+                paddingX="14px"
+                color="#43474E"
+              >
+                <Typography sx={{ fontWeight: 500, fontSize: 14 }}>
+                  {tag.choice}
+                </Typography>
+              </Box>
+            ))}
+          </Box>
+        </Box>
+        <Box
+          marginTop="16px"
+          display={hasPassed(question) || isUserTA ? "none" : "flex"}
+          justifyContent="flex-end"
         >
-          {question.title}
-        </Typography>
-        <Typography
-          style={{
-            fontSize: "14px",
-            marginTop: "8px",
-            color: "#43474E",
-            textOverflow: "ellipsis",
-            overflow: "hidden",
-          }}
-        >
-          {question.description}
-        </Typography>
-      </Box>
-      <Box marginTop="32px">
-        <Box display="flex" columnGap="16px" rowGap="8px" flexWrap="wrap">
-          {question.tags.map((tag) => (
-            <Box
-              key={tag.choice}
-              border={1}
-              borderColor="#73777F"
-              borderRadius="10px"
-              paddingY="4px"
-              paddingX="14px"
-              color="#43474E"
-            >
-              <Typography sx={{ fontWeight: 500, fontSize: 14 }}>
-                {tag.choice}
-              </Typography>
-            </Box>
-          ))}
+          <CustomButton
+            variant="contained"
+            customColor={
+              joinGroup
+                ? theme.palette.primary.light
+                : theme.palette.primary.main
+            }
+            sx={{
+              paddingY: "10px",
+              paddingX: "24px",
+              borderRadius: "32px",
+              color: joinGroup ? "#000" : "#fff",
+              textTransform: "none",
+              marginTop: "16px",
+            }}
+          >
+            {joinGroup ? "Leave group" : "Join group"}
+          </CustomButton>
         </Box>
       </Box>
-      <Box
-        marginTop="16px"
-        display={hasPassed(question) || isUserTA ? "none" : "flex"}
-        justifyContent="flex-end"
-      >
-        <CustomButton
-          variant="contained"
-          customColor={
-            joinGroup ? theme.palette.primary.light : theme.palette.primary.main
-          }
-          sx={{
-            paddingY: "10px",
-            paddingX: "24px",
-            borderRadius: "32px",
-            color: joinGroup ? "#000" : "#fff",
-            textTransform: "none",
-            marginTop: "16px",
-          }}
-          onClick={() =>
-            router.push(`${window.location.pathname}/${question.id}`)
-          }
-        >
-          {joinGroup ? "Leave group" : "Join group"}
-        </CustomButton>
-      </Box>
-    </Box>
+    </Link>
   );
 };
 

--- a/src/app/private/course/[courseId]/board/page.tsx
+++ b/src/app/private/course/[courseId]/board/page.tsx
@@ -31,7 +31,7 @@ const Page = (props: PageProps) => {
   return (
     <Box>
       <Header
-        title="Public Board"
+        title="Public Questions"
         leftIcon={<MenuButton isEdge />}
         rightIcon={
           <Link href={`/private/course/${courseId}/board/history`}>
@@ -39,12 +39,12 @@ const Page = (props: PageProps) => {
               style={{
                 textTransform: "none",
                 padding: 0,
-                width: "100px",
                 justifyContent: "end",
+                textWrap: "nowrap",
               }}
             >
               <Typography variant="subtitle2">
-                View {isUserTA ? "Response" : null} History
+                View {isUserTA ? "Response" : ""} History
               </Typography>
             </Button>
           </Link>

--- a/src/app/private/course/[courseId]/layout.tsx
+++ b/src/app/private/course/[courseId]/layout.tsx
@@ -28,7 +28,7 @@ const Layout = (props: ILayout) => {
       href: `/private/course/${courseId}`,
     },
     {
-      label: "Board",
+      label: "Public",
       icon: <StickyNote2OutlinedIcon />,
       href: `/private/course/${courseId}/board`,
     },

--- a/src/app/private/course/join/page.tsx
+++ b/src/app/private/course/join/page.tsx
@@ -5,11 +5,7 @@ import { Button, IconButton, TextField, Typography } from "@mui/material";
 import CloseIcon from "@mui/icons-material/Close";
 import React from "react";
 import { useRouter } from "next/navigation";
-import {
-  getCourseByCode,
-  getCourses,
-  joinCourse,
-} from "services/client/course";
+import { getCourseByCode, joinCourse } from "services/client/course";
 import { useUserSession } from "@context/UserSessionContext";
 import { CustomModal } from "@components/CustomModal";
 import useApiThrottle from "@hooks/useApiThrottle";

--- a/src/app/private/course/page.tsx
+++ b/src/app/private/course/page.tsx
@@ -1,30 +1,7 @@
-"use client";
-
-import Header from "@components/Header";
-import { Button, Typography } from "@mui/material";
-import { useRouter } from "next/navigation";
-import MenuButton from "@components/buttons/MenuButton";
+import { EnrolledCourses } from "@components/EnrolledCourses";
 
 const Page = () => {
-  const router = useRouter();
-  
-  return (
-    <div className="flex flex-col min-h-screen">
-      <Header leftIcon={<MenuButton />} title="Classes" />
-      {/* NOTE: Currently only displays the case where a user has no classes */}
-      <div className="flex flex-col items-center justify-center flex-grow gap-4">
-        <div>Add a class to get started</div>
-        <Button
-          className="py-2.5 px-6 bg-[#38608F] rounded-full normal-case"
-          onClick={() => router.push("/private/course/join")}
-        >
-          <Typography variant="subtitle2" color="#FFFFFF" fontWeight={600}>
-            Join class
-          </Typography>
-        </Button>
-      </div>
-    </div>
-  );
+  return <EnrolledCourses />;
 };
 
 export default Page;

--- a/src/app/services/client/course.ts
+++ b/src/app/services/client/course.ts
@@ -1,5 +1,9 @@
 import { db } from "../../../../firebase";
-import { IdentifiableCourse, IdentifiableCourses } from "@interfaces/type";
+import {
+  IdentifiableCourse,
+  IdentifiableCourses,
+  IdentifiableUser,
+} from "@interfaces/type";
 import { courseConverter, userConverter } from "../firestore";
 import {
   collection,
@@ -145,6 +149,22 @@ export const getCourses = async () => {
     collection(db, `courses`).withConverter(courseConverter)
   );
   const coursesDocs: IdentifiableCourses = snapshot.docs.map((doc) => ({
+    id: doc.id,
+    ...doc.data(),
+  }));
+
+  return coursesDocs;
+};
+
+export const getUserCourses = async (user: IdentifiableUser) => {
+  const coursesQuery = query(
+    collection(db, "courses"),
+    where(documentId(), "in", user.courses)
+  );
+
+  const snapshot = await getDocs(coursesQuery.withConverter(courseConverter));
+
+  const coursesDocs: IdentifiableCourse[] = snapshot.docs.map((doc) => ({
     id: doc.id,
     ...doc.data(),
   }));

--- a/src/app/utils/index.ts
+++ b/src/app/utils/index.ts
@@ -1,5 +1,4 @@
 import { defaultQuestion } from "@api/question";
-import { useUserSession } from "@context/UserSessionContext";
 import { Announcement, QuestionState } from "@interfaces/db";
 import {
   IdentifiableQuestion,
@@ -7,8 +6,6 @@ import {
   IdentifiableUser,
 } from "@interfaces/type";
 import { Timestamp } from "firebase/firestore";
-import { useRouter } from "next/navigation";
-import React from "react";
 
 export const trimUserName = (user: IdentifiableUser | undefined | null) => {
   if (user === undefined || user === null) {


### PR DESCRIPTION
# Description
In this PR,
- Implemented /private/course per new designs with currently joined classes
- Sidebar modifications (logout button, gap spacing) per designers
- Changed Board -> Public and renamed to Public Questions
- Reroute Manage Classes to `/private` in the mean time until we set up edit classes
- New Commit: Added Editing Location & Hours and Manage Classes now push `/private/course`
<!-- Include a summary of your changes -->

## Issues
Solve #51 #59
<!-- Reference the issue that you're working on (if exists) -->
<!-- When you references an issue, Github will automatically link the PR to Github -->
<!-- For example, "Resolve #1" links your PR to the first issue -->
<!-- For a full list of keywords, see here https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue -->

## Screenshots
Before:
<img width="298" alt="= Public Board" src="https://github.com/user-attachments/assets/23693df0-b958-42d6-9d6b-03e8bc0f8c75" />

After:
<img width="304" alt="CS160 Algorithms" src="https://github.com/user-attachments/assets/4ee626e2-9c77-4f82-86f9-06e2f7d74e55" />
<img width="302" alt="= Public Questions" src="https://github.com/user-attachments/assets/3b53d903-1a5a-482a-9e19-d076fea471e6" />

<!-- If you're making UI changes, please include screenshots and describe the expected user flow. -->

## Test
1. Test Empty Classes on `private/course`
2. Test User with Classses on `private/course`
3. Test if Sidebar navigation Manage Classes goes to correct route on empty class / and non-empty class
4. Test Sidebar functionality

