### PR TITLE
Queue indicators for private & public questions

### DIFF
--- a/src/app/components/queue/QueueItem.tsx
+++ b/src/app/components/queue/QueueItem.tsx
@@ -29,11 +29,6 @@ const QueueItem = (props: QueueItemProps) => {
   const isShowDetails =
     isUserTA || question.questionPublic || question.group[0] === user.id;
 
-  const privateTemplate = {
-    title: "Private",
-    user: "Anonymous",
-  };
-
   React.useEffect(() => {
     const fetchUsers = async () => {
       const fetchedUsers = await getUsers(question.group);
@@ -73,7 +68,7 @@ const QueueItem = (props: QueueItemProps) => {
           overflow="hidden"
           textOverflow="ellipsis"
         >
-          {isShowDetails ? question.title : privateTemplate.title}
+          {isShowDetails ? question.title : "Private"}
         </Typography>
         <Typography
           fontSize="14px"
@@ -82,11 +77,7 @@ const QueueItem = (props: QueueItemProps) => {
           overflow="hidden"
           textOverflow="ellipsis"
         >
-          {loading
-            ? "Loading..."
-            : isShowDetails
-            ? users.map(trimUserName).join(", ")
-            : privateTemplate.user}
+          {loading ? "Loading..." : users.map(trimUserName).join(", ")}
         </Typography>
       </Grid>
       <Grid item xs={2} textAlign="center">

--- a/src/app/components/queue/QueueItem.tsx
+++ b/src/app/components/queue/QueueItem.tsx
@@ -6,6 +6,7 @@ import React from "react";
 import { getUsers } from "@services/client/user";
 import { useRouter } from "next/navigation";
 import { useOfficeHour } from "@hooks/oh/useOfficeHour";
+import { LockOutlined } from "@mui/icons-material";
 
 interface QueueItemProps {
   order: number;
@@ -47,10 +48,16 @@ const QueueItem = (props: QueueItemProps) => {
       container
       columnSpacing="2px"
       alignItems="center"
+      paddingX="8px"
       onClick={() => {
         if (isShowDetails) {
           router.push(`queue/${question.id}`);
         }
+      }}
+      sx={{
+        ":hover": {
+          cursor: "pointer",
+        },
       }}
     >
       <Grid item xs={1}>
@@ -58,7 +65,7 @@ const QueueItem = (props: QueueItemProps) => {
           {order}
         </Typography>
       </Grid>
-      <Grid item xs={10}>
+      <Grid item xs={9}>
         <Typography
           fontSize="16px"
           color="#191C20"
@@ -82,8 +89,12 @@ const QueueItem = (props: QueueItemProps) => {
             : privateTemplate.user}
         </Typography>
       </Grid>
-      <Grid item xs={1}>
-        {isShowDetails && <ArrowRightOutlinedIcon sx={{ color: "#49454F" }} />}
+      <Grid item xs={2} textAlign="center">
+        {isShowDetails ? (
+          <ArrowRightOutlinedIcon sx={{ color: "#49454F" }} />
+        ) : (
+          <LockOutlined sx={{ color: "#49454F", fontSize: "18px" }} />
+        )}
       </Grid>
     </Grid>
   );

--- a/src/app/components/queue/QueueItem.tsx
+++ b/src/app/components/queue/QueueItem.tsx
@@ -25,6 +25,13 @@ const QueueItem = (props: QueueItemProps) => {
     return null;
   }
   const isUserTA = course.tas.includes(user.id);
+  const isShowDetails =
+    isUserTA || question.questionPublic || question.group[0] === user.id;
+
+  const privateTemplate = {
+    title: "Private",
+    user: "Anonymous",
+  };
 
   React.useEffect(() => {
     const fetchUsers = async () => {
@@ -41,7 +48,7 @@ const QueueItem = (props: QueueItemProps) => {
       columnSpacing="2px"
       alignItems="center"
       onClick={() => {
-        if (isUserTA) {
+        if (isShowDetails) {
           router.push(`queue/${question.id}`);
         }
       }}
@@ -59,7 +66,7 @@ const QueueItem = (props: QueueItemProps) => {
           overflow="hidden"
           textOverflow="ellipsis"
         >
-          {question.title}
+          {isShowDetails ? question.title : privateTemplate.title}
         </Typography>
         <Typography
           fontSize="14px"
@@ -68,11 +75,15 @@ const QueueItem = (props: QueueItemProps) => {
           overflow="hidden"
           textOverflow="ellipsis"
         >
-          {loading ? "Loading..." : users.map(trimUserName).join(", ")}
+          {loading
+            ? "Loading..."
+            : isShowDetails
+            ? users.map(trimUserName).join(", ")
+            : privateTemplate.user}
         </Typography>
       </Grid>
       <Grid item xs={1}>
-        <ArrowRightOutlinedIcon sx={{ color: "#49454F" }} />
+        {isShowDetails && <ArrowRightOutlinedIcon sx={{ color: "#49454F" }} />}
       </Grid>
     </Grid>
   );

--- a/src/app/components/queue/QueueList.tsx
+++ b/src/app/components/queue/QueueList.tsx
@@ -1,6 +1,6 @@
 import { IdentifiableQuestions } from "@interfaces/type";
 import PersonOutlineOutlined from "@mui/icons-material/PersonOutlineOutlined";
-import { Box, Stack, Typography } from "@mui/material";
+import { Box, Grid, Stack, Typography } from "@mui/material";
 import QueueItem from "./QueueItem";
 
 interface QueueListProps {
@@ -18,30 +18,37 @@ const QueueList = (props: QueueListProps) => {
 
   return (
     <Box>
-      <Box
+      <Grid
+        container
         display="flex"
         flexDirection="row"
         justifyContent="space-between"
         alignItems="center"
       >
-        <Typography
-          color="#545F70"
-          fontWeight={700}
-          fontSize={18}
-          component="h2"
-        >
-          {header}
-        </Typography>
-        <Box
+        <Grid item xs={10}>
+          <Typography
+            color="#545F70"
+            fontWeight={700}
+            fontSize={18}
+            component="h2"
+          >
+            {header}
+          </Typography>
+        </Grid>
+        <Grid
+          item
+          xs={2}
           display="flex"
           alignItems="center"
-          columnGap="8px"
+          justifyContent="center"
+          columnGap="4px"
+          paddingLeft="8px"
           visibility={displayEnqueued ? "visible" : "hidden"}
         >
           <PersonOutlineOutlined fontSize="small" />
-          <Typography>{questions.length}</Typography>
-        </Box>
-      </Box>
+          <Typography fontWeight={500}>{questions.length}</Typography>
+        </Grid>
+      </Grid>
       <Stack spacing="8px" marginTop="16px">
         {questions.map((question, index) => (
           <QueueItem key={question.id} order={index + 1} question={question} />


### PR DESCRIPTION
# Description

Added a clearer indicator for private and public questions per Figma designs. TA can see all questions, users who post a private question can see while others can't.

Additional:

- Changed styling of queue header and queue items to match Figma designs on all screens
- Keeping question title and users to "Private" and "Anonymous" and awaiting decision from designers for further updates
- Added hover pointer cursor for clearer distinction of queue item being clickable (only works for non-mobile tho)

## Issues

 #54 

## Screenshots

Before:

<img width="337" alt="image" src="https://github.com/user-attachments/assets/68bc5e4a-4aef-4def-a453-86fa7c2b0cb6" />

With changes:

<img width="330" alt="image" src="https://github.com/user-attachments/assets/1614cdcc-6053-4194-bde3-9fd2b9b54d40" />

## Test

Tested on different student screens + TA screen making sure that routing goes to question details

## Possible Downsides

None hopefully

## Additional Documentations

Figma styling:

<img width="305" alt="image" src="https://github.com/user-attachments/assets/225f7c96-7186-4039-acf6-a53c6b0fb091" />

