### PR TITLE
Add some gap to TA list

### DIFF
--- a/src/app/components/StudentDisplayCourse.tsx
+++ b/src/app/components/StudentDisplayCourse.tsx
@@ -24,7 +24,6 @@ const StudentDisplayCourse = (props: StudentDisplayCourseProps) => {
         flexDirection: "column",
         gap: "32px",
         marginTop: "24px",
-        height: "100vh",
       }}
     >
       <DisplayAnnouncements


### PR DESCRIPTION
# Description

Prior to the change, `100-vh` hides the last TAs

<img width="497" alt="image" src="https://github.com/user-attachments/assets/cdec4013-f04b-4f0b-88d4-7e1f69da4ba2" />

After the change, we have some empty space at the end

<img width="452" alt="image" src="https://github.com/user-attachments/assets/9d42f2dd-ed5d-400a-9e98-5eae60ced4f3" />