### PR TITLE
Show 'you're next' and add student missing screen

### DIFF
--- a/src/app/components/queue/EditQuestion.tsx
+++ b/src/app/components/queue/EditQuestion.tsx
@@ -1,17 +1,14 @@
 import { Box, Button, Container } from "@mui/material";
 import NotificationAddOutlinedIcon from "@mui/icons-material/NotificationAddOutlined";
 import KeyboardReturnOutlinedIcon from "@mui/icons-material/KeyboardReturnOutlined";
-import NotificationsActiveOutlinedIcon from "@mui/icons-material/NotificationsActiveOutlined";
 import { useOfficeHour } from "@hooks/oh/useOfficeHour";
 import React from "react";
 import { CustomModal } from "@components/CustomModal";
 import { leaveQuestionGroup } from "@services/client/question";
 import QuestionForm from "./form/QuestionForm";
 import { useUserOrRedirect } from "@hooks/useUserOrRedirect";
-import TaCard from "@components/tas/TaCard";
 import { useCourseData } from "@hooks/useCourseData";
 import Spinner from "@components/Spinner";
-import { QuestionDetails } from "@components/board/QuestionDetails";
 import { IdentifiableQuestion } from "@interfaces/type";
 import { QuestionState } from "@interfaces/db";
 import { StudentHelping } from "./StudentHelping";
@@ -128,7 +125,7 @@ export const EditQuestion = (props: editQuestionProps) => {
         }}
       >
         <Box sx={{ fontWeight: 700, fontSize: position === 0 ? 35 : 55 }}>
-          {position === 0 ? "You're Next!" : position}
+          {position === 0 ? "You're Next!" : position + 1}
         </Box>
         {position !== 0 && (
           <Box sx={{ fontWeight: 500, fontSize: 10, color: "#545F70" }}>

--- a/src/app/components/queue/EditQuestion.tsx
+++ b/src/app/components/queue/EditQuestion.tsx
@@ -124,14 +124,13 @@ export const EditQuestion = (props: editQuestionProps) => {
           alignItems: "center",
         }}
       >
-        <Box sx={{ fontWeight: 700, fontSize: position === 0 ? 35 : 55 }}>
+        <Box sx={{ fontWeight: 400, fontSize: '12px', color: "#545F70" }}>
+            Your queue position
+          </Box>
+        <Box sx={{ fontWeight: 700, fontSize: '57px' }}>
           {position === 0 ? "You're Next!" : position + 1}
         </Box>
-        {position !== 0 && (
-          <Box sx={{ fontWeight: 500, fontSize: 10, color: "#545F70" }}>
-            Queues ahead of you
-          </Box>
-        )}
+        
         <Box
           sx={{
             fontWeight: 400,

--- a/src/app/components/queue/EditQuestion.tsx
+++ b/src/app/components/queue/EditQuestion.tsx
@@ -34,36 +34,6 @@ export const EditQuestion = (props: editQuestionProps) => {
 
   const [leaveQueueModal, setLeaveQueueModal] = React.useState<boolean>(false);
 
-  // not in queue, not join any question,
-  // and not have any IN_PROGRESS or MISSING question
-  if (queuePos === -1 && groupPos === -1 && currQuestion.title === "") {
-    return null;
-  }
-  const position =
-    queuePos === -1
-      ? groupPos
-      : groupPos === -1
-      ? queuePos
-      : Math.min(queuePos, groupPos);
-
-  if (loading) {
-    return (
-      <div className="flex items-center justify-center h-screen ">
-        <Spinner />
-      </div>
-    );
-  }
-
-  if (currQuestion.state === QuestionState.IN_PROGRESS) {
-    const ta = tas.find((myTa) => myTa.id === currQuestion.helpedBy);
-    return (
-      <StudentHelping currQuestion={currQuestion} course={course} ta={ta!} />
-    );
-  }
-  if (currQuestion.state === QuestionState.MISSING) {
-    return <StudentMissing currQuestion={currQuestion} course={course} />;
-  }
-
   const leaveQueue = () => {
     leaveQuestionGroup(currQuestion, course.id, user.id);
     setLeaveQueueModal(false);
@@ -98,6 +68,36 @@ export const EditQuestion = (props: editQuestionProps) => {
       Edit submission
     </Button>
   );
+
+  // not in queue, not join any question,
+  // and not have any IN_PROGRESS or MISSING question
+  if (queuePos === -1 && groupPos === -1 && currQuestion.title === "") {
+    return null;
+  }
+  const position =
+    queuePos === -1
+      ? groupPos
+      : groupPos === -1
+      ? queuePos
+      : Math.min(queuePos, groupPos);
+
+  if (loading) {
+    return (
+      <div className="flex items-center justify-center h-screen ">
+        <Spinner />
+      </div>
+    );
+  }
+
+  if (currQuestion.state === QuestionState.IN_PROGRESS) {
+    const ta = tas.find((myTa) => myTa.id === currQuestion.helpedBy);
+    return (
+      <StudentHelping currQuestion={currQuestion} course={course} ta={ta!} />
+    );
+  }
+  if (currQuestion.state === QuestionState.MISSING) {
+    return <StudentMissing currQuestion={currQuestion} course={course} />;
+  }
 
   return (
     <>

--- a/src/app/components/queue/EditQuestion.tsx
+++ b/src/app/components/queue/EditQuestion.tsx
@@ -1,4 +1,4 @@
-import { Box, Button, Container } from "@mui/material";
+import { Box, Button, Container, Typography } from "@mui/material";
 import NotificationAddOutlinedIcon from "@mui/icons-material/NotificationAddOutlined";
 import KeyboardReturnOutlinedIcon from "@mui/icons-material/KeyboardReturnOutlined";
 import { useOfficeHour } from "@hooks/oh/useOfficeHour";
@@ -34,12 +34,12 @@ export const EditQuestion = (props: EditQuestionProps) => {
 
   const [leaveQueueModal, setLeaveQueueModal] = React.useState<boolean>(false);
 
-  const leaveQueue = () => {
-    leaveQuestionGroup(currQuestion, course.id, user.id);
+  const leaveQueue = async () => {
+    await leaveQuestionGroup(currQuestion, course.id, user.id);
     setLeaveQueueModal(false);
   };
-  const leaveGroup = () => {
-    leaveQuestionGroup(groupQuestion, course.id, user.id);
+  const leaveGroup = async () => {
+    await leaveQuestionGroup(groupQuestion, course.id, user.id);
   };
 
   const leaveQueueButtons = [
@@ -74,12 +74,14 @@ export const EditQuestion = (props: EditQuestionProps) => {
   if (queuePos === -1 && groupPos === -1 && currQuestion.title === "") {
     return null;
   }
+
   const position =
     queuePos === -1
       ? groupPos
       : groupPos === -1
       ? queuePos
       : Math.min(queuePos, groupPos);
+
   const isAuthor = position === queuePos;
 
   if (loading) {
@@ -125,12 +127,16 @@ export const EditQuestion = (props: EditQuestionProps) => {
           alignItems: "center",
         }}
       >
-        <Box sx={{ fontWeight: 400, fontSize: "12px", color: "#545F70" }}>
+        <Typography
+          sx={{ fontWeight: 400, fontSize: "16px", color: "#545F70" }}
+        >
           Your queue position
-        </Box>
-        <Box sx={{ fontWeight: 700, fontSize: "57px", textAlign: "center" }}>
-          {position === 0 ? "You're Next!" : position + 1}
-        </Box>
+        </Typography>
+        <Typography
+          sx={{ fontWeight: 700, fontSize: "45px", textAlign: "center" }}
+        >
+          {position === 0 ? "You're next!" : position + 1}
+        </Typography>
 
         <Box
           sx={{
@@ -138,12 +144,15 @@ export const EditQuestion = (props: EditQuestionProps) => {
             fontSize: 12,
             display: "flex",
             flexDirection: "row",
-            columnGap: 0.5,
+            gap: 1,
             color: "#545F70",
+            alignItems: "center",
           }}
         >
           <NotificationAddOutlinedIcon style={{ fontSize: "16px" }} />
-          <Box> We'll notify you when it's your turn</Box>
+          <Typography sx={{ fontSize: "16px" }}>
+            We'll notify you when it's your turn
+          </Typography>
         </Box>
         <Box
           sx={{
@@ -177,7 +186,7 @@ export const EditQuestion = (props: EditQuestionProps) => {
               }
             >
               <KeyboardReturnOutlinedIcon style={{ fontSize: "14px" }} />
-              {isAuthor ? <Box>Leave queue</Box> : <Box>Leave group</Box>}
+              {isAuthor ? "Leave queue " : "Leave group"}
             </Button>
           </Box>
           {isAuthor && (

--- a/src/app/components/queue/EditQuestion.tsx
+++ b/src/app/components/queue/EditQuestion.tsx
@@ -14,14 +14,14 @@ import { QuestionState } from "@interfaces/db";
 import { StudentHelping } from "./StudentHelping";
 import { StudentMissing } from "./StudentMissing";
 
-interface editQuestionProps {
+interface EditQuestionProps {
   queuePos: number;
   groupPos: number;
   currQuestion: IdentifiableQuestion;
   groupQuestion: IdentifiableQuestion;
 }
 
-export const EditQuestion = (props: editQuestionProps) => {
+export const EditQuestion = (props: EditQuestionProps) => {
   const { queuePos, groupPos, currQuestion, groupQuestion } = props;
   const { course } = useOfficeHour();
   const { tas, loading } = useCourseData({
@@ -80,12 +80,13 @@ export const EditQuestion = (props: editQuestionProps) => {
       : groupPos === -1
       ? queuePos
       : Math.min(queuePos, groupPos);
+  const isAuthor = position === queuePos;
 
   if (loading) {
     return (
-      <div className="flex items-center justify-center h-screen ">
+      <Box className="flex items-center justify-center h-screen ">
         <Spinner />
-      </div>
+      </Box>
     );
   }
 
@@ -101,7 +102,7 @@ export const EditQuestion = (props: editQuestionProps) => {
 
   return (
     <>
-      {position === queuePos && (
+      {isAuthor && (
         <CustomModal
           title="Leave queue?"
           subtitle="You'll lose your place in line and
@@ -124,13 +125,13 @@ export const EditQuestion = (props: editQuestionProps) => {
           alignItems: "center",
         }}
       >
-        <Box sx={{ fontWeight: 400, fontSize: '12px', color: "#545F70" }}>
-            Your queue position
-          </Box>
-        <Box sx={{ fontWeight: 700, fontSize: '57px' }}>
+        <Box sx={{ fontWeight: 400, fontSize: "12px", color: "#545F70" }}>
+          Your queue position
+        </Box>
+        <Box sx={{ fontWeight: 700, fontSize: "57px", textAlign: "center" }}>
           {position === 0 ? "You're Next!" : position + 1}
         </Box>
-        
+
         <Box
           sx={{
             fontWeight: 400,
@@ -172,18 +173,14 @@ export const EditQuestion = (props: editQuestionProps) => {
               style={{ boxShadow: "none" }}
               fullWidth
               onClick={() =>
-                position === queuePos ? setLeaveQueueModal(true) : leaveGroup()
+                isAuthor ? setLeaveQueueModal(true) : leaveGroup()
               }
             >
               <KeyboardReturnOutlinedIcon style={{ fontSize: "14px" }} />
-              {position === queuePos ? (
-                <Box>Leave queue</Box>
-              ) : (
-                <Box>Leave group</Box>
-              )}
+              {isAuthor ? <Box>Leave queue</Box> : <Box>Leave group</Box>}
             </Button>
           </Box>
-          {position === queuePos && (
+          {isAuthor && (
             <Box sx={{ flexGrow: 1 }}>
               <QuestionForm
                 triggerButton={editButton}

--- a/src/app/components/queue/StudentHelping.tsx
+++ b/src/app/components/queue/StudentHelping.tsx
@@ -1,0 +1,84 @@
+import { QuestionDetails } from "@components/board/QuestionDetails";
+import TaCard from "@components/tas/TaCard";
+import {
+  IdentifiableCourse,
+  IdentifiableQuestion,
+  IdentifiableUser,
+} from "@interfaces/type";
+import NotificationAddOutlinedIcon from "@mui/icons-material/NotificationAddOutlined";
+import { Box } from "@mui/material";
+
+interface studentHelpingProps {
+  currQuestion: IdentifiableQuestion;
+  course: IdentifiableCourse;
+  ta: IdentifiableUser;
+}
+
+export const StudentHelping = (props: studentHelpingProps) => {
+  const { currQuestion, course, ta } = props;
+
+  return (
+    <Box
+      sx={{
+        display: "flex",
+        flexDirection: "column",
+        gap: "10px",
+        color: "#43474E",
+      }}
+    >
+      <Box
+        sx={{
+          display: "flex",
+          flexDirection: "row",
+          columnGap: "10px",
+          padding: "16px",
+          bgcolor: "#D7E3F8",
+          justifyContent: "center",
+          marginLeft: "-16px",
+          marginTop: "-18px",
+          width: "100vw",
+        }}
+      >
+        <NotificationAddOutlinedIcon style={{ fontSize: "20px" }} />
+        <Box fontWeight={500} fontSize="14px">
+          It's your turn
+        </Box>
+      </Box>
+
+      <Box
+        sx={{
+          paddingTop: "20px",
+          paddingRight: "10px",
+          paddingLeft: "10px",
+          fontWeight: 700,
+          color: "#545F70",
+          fontSize: "18.98px",
+        }}
+      >
+        Your TA
+      </Box>
+      <Box sx={{ paddingLeft: "10px" }}>
+        <TaCard ta={ta!} />
+      </Box>
+
+      <Box
+        sx={{
+          paddingTop: "20px",
+          paddingRight: "10px",
+          paddingLeft: "10px",
+          fontWeight: 700,
+          color: "#545F70",
+          fontSize: "18.98px",
+        }}
+      >
+        Your Question
+      </Box>
+      <QuestionDetails
+        question={currQuestion}
+        courseId={course.id}
+        fromStudentCurrentHelping
+      />
+    </Box>
+  );
+};
+

--- a/src/app/components/queue/StudentHelping.tsx
+++ b/src/app/components/queue/StudentHelping.tsx
@@ -8,13 +8,13 @@ import {
 import NotificationAddOutlinedIcon from "@mui/icons-material/NotificationAddOutlined";
 import { Box } from "@mui/material";
 
-interface studentHelpingProps {
+interface StudentHelpingProps {
   currQuestion: IdentifiableQuestion;
   course: IdentifiableCourse;
   ta: IdentifiableUser;
 }
 
-export const StudentHelping = (props: studentHelpingProps) => {
+export const StudentHelping = (props: StudentHelpingProps) => {
   const { currQuestion, course, ta } = props;
 
   return (

--- a/src/app/components/queue/StudentMissing.tsx
+++ b/src/app/components/queue/StudentMissing.tsx
@@ -6,12 +6,12 @@ import {
 import ErrorOutlineOutlinedIcon from '@mui/icons-material/ErrorOutlineOutlined';
 import { Box } from "@mui/material";
 
-interface studentMissingProps {
+interface StudentMissingProps {
   currQuestion: IdentifiableQuestion;
   course: IdentifiableCourse;
 }
 
-export const StudentMissing = (props: studentMissingProps) => {
+export const StudentMissing = (props: StudentMissingProps) => {
   const { currQuestion, course } = props;
 
   return (

--- a/src/app/components/queue/StudentMissing.tsx
+++ b/src/app/components/queue/StudentMissing.tsx
@@ -1,0 +1,65 @@
+import { QuestionDetails } from "@components/board/QuestionDetails";
+import {
+  IdentifiableCourse,
+  IdentifiableQuestion,
+} from "@interfaces/type";
+import ErrorOutlineOutlinedIcon from '@mui/icons-material/ErrorOutlineOutlined';
+import { Box } from "@mui/material";
+
+interface studentMissingProps {
+  currQuestion: IdentifiableQuestion;
+  course: IdentifiableCourse;
+}
+
+export const StudentMissing = (props: studentMissingProps) => {
+  const { currQuestion, course } = props;
+
+  return (
+    <Box
+      sx={{
+        display: "flex",
+        flexDirection: "column",
+        gap: "10px",
+        color: "#43474E",
+      }}
+    >
+      <Box
+        sx={{
+          display: "flex",
+          flexDirection: "row",
+          columnGap: "10px",
+          padding: "16px",
+          bgcolor: "#FFDAD6",
+          justifyContent: "center",
+          marginLeft: "-16px",
+          marginTop: "-18px",
+          width: "100vw",
+        }}
+      >
+        <ErrorOutlineOutlinedIcon style={{ fontSize: "20px", color: "#FF0000" }} />
+        <Box fontWeight={500} fontSize="14px">
+          You were marked as missing. Notify your TA.
+        </Box>
+      </Box>
+
+      <Box
+        sx={{
+          paddingTop: "20px",
+          paddingRight: "10px",
+          paddingLeft: "10px",
+          fontWeight: 700,
+          color: "#545F70",
+          fontSize: "18.98px",
+        }}
+      >
+        Your Question
+      </Box>
+      <QuestionDetails
+        question={currQuestion}
+        courseId={course.id}
+        fromStudentCurrentHelping
+      />
+    </Box>
+  );
+};
+

--- a/src/app/private/course/[courseId]/queue/page.tsx
+++ b/src/app/private/course/[courseId]/queue/page.tsx
@@ -35,7 +35,10 @@ const Page = () => {
     return null;
   }
   const isUserTA = course.tas.includes(user.id);
-  const { queuePos, currQuestion } = getQueuePosition(questions, user);
+  const { queuePos, groupPos, currQuestion, groupQuestion } = getQueuePosition(
+    questions,
+    user
+  );
   const queueClosed = course.onDuty.length === 0 || !course.isOpen;
 
   React.useEffect(() => {
@@ -131,13 +134,20 @@ const Page = () => {
           ) : (
             <>
               {!queueClosed && (
-                <EditQuestion queuePos={queuePos} currQuestion={currQuestion} />
+                <EditQuestion
+                  queuePos={queuePos}
+                  groupPos={groupPos}
+                  currQuestion={currQuestion}
+                  groupQuestion={groupQuestion}
+                />
               )}
-              {currQuestion.helpedBy === "" && <CreateQuestion />}
+              {currQuestion.state === QuestionState.PENDING && (
+                <CreateQuestion />
+              )}
             </>
           )}
 
-          {currQuestion.helpedBy === "" && <Queue />}
+          {currQuestion.state === QuestionState.PENDING && <Queue />}
         </>
       ) : (
         <Box>

--- a/src/app/utils/index.ts
+++ b/src/app/utils/index.ts
@@ -168,9 +168,19 @@ export const getQueuePosition = (
   const position = sortedActiveQuestions.findIndex(
     (q) => q.group[0] === user.id
   );
+  const groupPos = sortedActiveQuestions.findIndex(
+    (q) => q.group.includes(user.id) && q.group[0] !== user.id
+  );
+
+  // queue position in PENDING queue
+  const pendingPos = sortedActiveQuestions
+    .filter((q) => q.state === QuestionState.PENDING)
+    .findIndex((q) => q.group[0] === user.id);
 
   return {
-    queuePos: position,
+    queuePos: pendingPos,
+    groupPos: groupPos,
     currQuestion: sortedActiveQuestions[position] ?? defaultQuestion(),
+    groupQuestion: sortedActiveQuestions[groupPos] ?? defaultQuestion(),
   };
 };

--- a/src/app/utils/index.ts
+++ b/src/app/utils/index.ts
@@ -7,8 +7,6 @@ import {
   IdentifiableUser,
 } from "@interfaces/type";
 import { Timestamp } from "firebase/firestore";
-import { useRouter } from "next/navigation";
-import React from "react";
 
 export const trimUserName = (user: IdentifiableUser | undefined | null) => {
   if (user === undefined || user === null) {
@@ -165,11 +163,14 @@ export const getQueuePosition = (
 ) => {
   const activeQuestions = getActiveQuestions(questions);
   const sortedActiveQuestions = sortQuestionsChronologically(activeQuestions);
+  const sortedPendingQuestions = sortedActiveQuestions.filter(
+    (q) => q.state === QuestionState.PENDING
+  );
   const position = sortedActiveQuestions.findIndex(
     (q) => q.group[0] === user.id
   );
-  const groupPos = sortedActiveQuestions.findIndex(
-    (q) => q.group.includes(user.id) && q.group[0] !== user.id
+  const groupPos = sortedPendingQuestions.findIndex((q) =>
+    q.group.includes(user.id)
   );
 
   // queue position in PENDING queue
@@ -181,6 +182,6 @@ export const getQueuePosition = (
     queuePos: pendingPos,
     groupPos: groupPos,
     currQuestion: sortedActiveQuestions[position] ?? defaultQuestion(),
-    groupQuestion: sortedActiveQuestions[groupPos] ?? defaultQuestion(),
+    groupQuestion: sortedPendingQuestions[groupPos] ?? defaultQuestion(),
   };
 };

--- a/src/app/utils/index.ts
+++ b/src/app/utils/index.ts
@@ -174,10 +174,10 @@ export const getQueuePosition = (
   );
 
   // queue position in PENDING queue
-  const pendingPos = sortedActiveQuestions
-    .filter((q) => q.state === QuestionState.PENDING)
-    .findIndex((q) => q.group[0] === user.id);
 
+  const pendingPos = sortedPendingQuestions.findIndex(
+    (q) => q.group[0] === user.id
+  );
   return {
     queuePos: pendingPos,
     groupPos: groupPos,


### PR DESCRIPTION
# Description
In this PR:
- Add student missing screen
- Make everyone in a group see the question's position in the queue
- Fix queue position off when there is missing queue or current helping queue

## Issues
Resolve #55, resolve #75, resolve #86
<!-- Reference the issue that you're working on (if exists) -->
<!-- When you references an issue, Github will automatically link the PR to Github -->
<!-- For example, "Resolve #1" links your PR to the first issue -->
<!-- For a full list of keywords, see here https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue -->

## Screenshots
- Student can see the position in queue of the question they join
<img width="311" alt="Screenshot 2025-01-28 at 5 58 48 PM" src="https://github.com/user-attachments/assets/b1bb3732-3cb2-466f-b4a8-210059364b87" />
<img width="302" alt="Screenshot 2025-01-28 at 6 02 28 PM" src="https://github.com/user-attachments/assets/5926a1d0-1957-4b53-baa8-ab178ac3d154" />

- Student missing screen
<img width="337" alt="Screenshot 2025-01-28 at 6 04 36 PM" src="https://github.com/user-attachments/assets/65840891-6b0d-4d97-bd28-2c130c0231c2" />

## Test
- Join a question to see if the queue position component shows up
- Join a question and create a question to see which question's position is shown in the position queue component
