### PR TITLE
Add Person Icon

### DIFF
--- a/src/app/components/queue/QueueList.tsx
+++ b/src/app/components/queue/QueueList.tsx
@@ -5,12 +5,11 @@ import QueueItem from "./QueueItem";
 
 interface QueueListProps {
   header: string;
-  displayEnqueued: boolean;
   questions: IdentifiableQuestions;
 }
 
 const QueueList = (props: QueueListProps) => {
-  const { header, displayEnqueued, questions } = props;
+  const { header, questions } = props;
 
   if (questions.length === 0) {
     return null;
@@ -43,7 +42,6 @@ const QueueList = (props: QueueListProps) => {
           justifyContent="center"
           columnGap="4px"
           paddingLeft="8px"
-          visibility={displayEnqueued ? "visible" : "hidden"}
         >
           <PersonOutlineOutlined fontSize="small" />
           <Typography fontWeight={500}>{questions.length}</Typography>

--- a/src/app/components/queue/index.tsx
+++ b/src/app/components/queue/index.tsx
@@ -31,17 +31,14 @@ const Queue = () => {
         <Stack spacing="36px" display={queueClosed ? "none" : "block"}>
           <QueueList
             header={isUserTA ? "Other TAs are helping" : "Currently Helping"}
-            displayEnqueued={false}
             questions={sortQuestionsChronologically(inProgressQuestions)}
           />
           <QueueList
             header="Missing"
-            displayEnqueued={false}
             questions={sortQuestionsChronologically(missingQuestions)}
           />
           <QueueList
             header={isUserTA ? "Start helping" : "Queue"}
-            displayEnqueued
             questions={sortQuestionsChronologically(pendingQuestions)}
           />
         </Stack>


### PR DESCRIPTION
# Description

Modified QueueList so it displays person icon for all queues

## Issues

#70 

## Screenshots

![Screenshot 2025-01-29 at 11 11 03 AM](https://github.com/user-attachments/assets/950e595d-0e31-46eb-9545-92b3ce86cb48)

## Test

Try adding many questions then helping some and marking some as missing. Check that the different queue states have the correct number of people next to the person icon

## Possible Downsides

Need to test for when a TA starts helping users, wasn't able to test alone because I can't see the queue when I'm helping someone

## Additional Documentations

None :)