### PR TITLE
fix: board + board history TA functionality, centralize error

### DIFF
--- a/src/app/components/board/QuestionDetails.tsx
+++ b/src/app/components/board/QuestionDetails.tsx
@@ -10,7 +10,7 @@ import {
 } from "@utils/index";
 import React from "react";
 import theme from "theme";
-import PeopleAltIcon from "@mui/icons-material/PeopleAlt";
+import PeopleAltOutlinedIcon from "@mui/icons-material/PeopleAltOutlined";
 import { getUser, getUsers } from "@services/client/user";
 import {
   getBatchedQuestions,
@@ -33,6 +33,7 @@ interface QuestionDetailsProps {
   fromTAQueue?: boolean;
   fromCurrentlyHelping?: boolean;
   fromStudentCurrentHelping?: boolean;
+  isUserTA: boolean;
 }
 
 export const QuestionDetails = (props: QuestionDetailsProps) => {
@@ -42,6 +43,7 @@ export const QuestionDetails = (props: QuestionDetailsProps) => {
     fromTAQueue = false,
     fromCurrentlyHelping = false,
     fromStudentCurrentHelping = false,
+    isUserTA = false,
   } = props;
 
   const user = useUserOrRedirect();
@@ -166,6 +168,7 @@ export const QuestionDetails = (props: QuestionDetailsProps) => {
               flexDirection="row"
               gap="16px"
               alignItems="center"
+              paddingX="8px"
               sx={{
                 marginTop: currentHelping ? "" : "24px",
               }}
@@ -241,21 +244,21 @@ export const QuestionDetails = (props: QuestionDetailsProps) => {
               </Box>
             </Box>
             <Box
-              marginTop="8px"
+              marginTop="12px"
               display={"flex"}
               flexDirection={"row"}
               alignItems="center"
             >
-              <PeopleAltIcon style={{ marginRight: 4 }} />
-              <Typography
-                sx={{ fontSize: 14, color: theme.palette.text.secondary }}
-              >
+              <PeopleAltOutlinedIcon
+                style={{ marginRight: 8, color: "#545F70" }}
+              />
+              <Typography sx={{ fontSize: 14, color: "#545F70" }}>
                 {users.map(trimUserName).join(", ")}&nbsp;
                 {users.length === 1 ? "is" : "are"} in this group.
               </Typography>
             </Box>
           </Box>
-          {fromCurrentlyHelping ? (
+          {fromCurrentlyHelping && isUserTA ? (
             <Box
               marginTop="8px"
               display={hasPassed(question) ? "none" : "flex"}
@@ -280,7 +283,7 @@ export const QuestionDetails = (props: QuestionDetailsProps) => {
                 Mark as done
               </CustomButton>
             </Box>
-          ) : fromTAQueue ? (
+          ) : fromTAQueue && isUserTA ? (
             <Box
               marginTop="8px"
               sx={{ display: "flex", flexDirection: "column", gap: "16px" }}
@@ -319,10 +322,10 @@ export const QuestionDetails = (props: QuestionDetailsProps) => {
                 </CustomButton>
               )}
             </Box>
-          ) : fromStudentCurrentHelping ? null : (
+          ) : fromStudentCurrentHelping && isUserTA ? null : (
             <Box
               marginTop="8px"
-              display={hasPassed(question) ? "none" : "flex"}
+              display={hasPassed(question) || isUserTA ? "none" : "flex"}
             >
               <CustomButton
                 variant="contained"

--- a/src/app/components/board/QuestionDetails.tsx
+++ b/src/app/components/board/QuestionDetails.tsx
@@ -33,7 +33,7 @@ interface QuestionDetailsProps {
   fromTAQueue?: boolean;
   fromCurrentlyHelping?: boolean;
   fromStudentCurrentHelping?: boolean;
-  isUserTA: boolean;
+  isUserTA?: boolean;
 }
 
 export const QuestionDetails = (props: QuestionDetailsProps) => {

--- a/src/app/components/queue/EditQuestion.tsx
+++ b/src/app/components/queue/EditQuestion.tsx
@@ -30,6 +30,7 @@ export const EditQuestion = (props: editQuestionProps) => {
   if (!user) {
     return null;
   }
+  const isUserTA = course.tas.includes(user.id);
 
   const [leaveQueueModal, setLeaveQueueModal] = React.useState<boolean>(false);
 
@@ -104,11 +105,12 @@ export const EditQuestion = (props: editQuestionProps) => {
         >
           Your Question
         </Box>
-          <QuestionDetails
-            question={currQuestion}
-            courseId={course.id}
-            fromStudentCurrentHelping
-          />
+        <QuestionDetails
+          question={currQuestion}
+          courseId={course.id}
+          isUserTA={isUserTA}
+          fromStudentCurrentHelping
+        />
       </Box>
     );
   }

--- a/src/app/not-found.tsx
+++ b/src/app/not-found.tsx
@@ -1,0 +1,6 @@
+import ErrorNavigation from "@components/ErrorNavigation";
+import React from "react";
+
+export default function NotFound() {
+  return <ErrorNavigation />;
+}

--- a/src/app/private/course/[courseId]/board/[questionId]/error.tsx
+++ b/src/app/private/course/[courseId]/board/[questionId]/error.tsx
@@ -1,9 +1,0 @@
-"use client";
-import ErrorNavigation from "@components/ErrorNavigation";
-import React from "react";
-
-const Error = () => {
-  return <ErrorNavigation />;
-};
-
-export default Error;

--- a/src/app/private/course/[courseId]/board/history/[questionId]/page.tsx
+++ b/src/app/private/course/[courseId]/board/history/[questionId]/page.tsx
@@ -28,7 +28,7 @@ const Page = (props: PageProps) => {
   const isUserTA = course.tas.includes(user.id);
 
   if (!question) {
-    router.push(`/private/course/${courseId}/board`);
+    router.push(`/private/course/${courseId}/board/history`);
     return;
   }
 
@@ -36,7 +36,7 @@ const Page = (props: PageProps) => {
     <div>
       <Header
         leftIcon={
-          <Link href={`/private/course/${courseId}/board`}>
+          <Link href={`/private/course/${courseId}/board/history`}>
             <ArrowBack sx={{ marginLeft: "-10px", color: "#000" }} />
           </Link>
         }

--- a/src/app/private/course/[courseId]/board/history/page.tsx
+++ b/src/app/private/course/[courseId]/board/history/page.tsx
@@ -31,7 +31,7 @@ const Page = (props: PageProps) => {
       <Header
         leftIcon={
           <Link href={`/private/course/${courseId}/board`}>
-            <ArrowBack sx={{ marginRight: "10px", color: "#000" }} />
+            <ArrowBack sx={{ marginLeft: "-4px", color: "#000" }} />
           </Link>
         }
         title={isUserTA ? "Response History" : "History"}

--- a/src/app/private/course/[courseId]/queue/[questionId]/page.tsx
+++ b/src/app/private/course/[courseId]/queue/[questionId]/page.tsx
@@ -42,6 +42,7 @@ const Page = (props: PageProps) => {
         courseId={courseId}
         question={question}
         fromTAQueue={isUserTA}
+        isUserTA={isUserTA}
       />
     </div>
   );

--- a/src/app/private/course/[courseId]/queue/page.tsx
+++ b/src/app/private/course/[courseId]/queue/page.tsx
@@ -222,6 +222,7 @@ const Page = () => {
           <QuestionDetails
             question={helpingQuestion}
             courseId={course.id}
+            isUserTA={isUserTA}
             fromCurrentlyHelping
           />
         </Box>


### PR DESCRIPTION
# Description

Previously, TA can still join questions if they exist on the board. This PR introduces the `isUserTA` prop to `QuestionDetails`:

- adds extra layer of protection for all button functionality for QuestionDetails
- checks to display "Join group" and "Leave group"

Additionally:

- centralizes all global URL mismatch through a `not-found.tsx` file as per the documentation link below
- re-styled the board/[qid] and board/history/[qid] to match Figma styling

## Issues

Trust me 😭

## Screenshots

Before/after:

<img width="481" alt="image" src="https://github.com/user-attachments/assets/c46244ab-a50a-4480-a5c0-46c28ad48cd9" />

<img width="458" alt="image" src="https://github.com/user-attachments/assets/f9430c4b-a39e-4b12-833a-fc775e7d6801" />

## Test

Tested user and TA view for question on board, history, board/qid, and history/qid. Users should have join/leave on board/qid and board and TA shouldn't. For history and history/qid, both users and TA do not have any buttons displayed.

## Possible Downsides

None that I know of so far...

## Additional Documentations

https://nextjs.org/docs/app/api-reference/file-conventions/not-found