### PR TITLE
Chunk Fetch for getUsers

### DIFF
--- a/src/app/private/course/[courseId]/page.tsx
+++ b/src/app/private/course/[courseId]/page.tsx
@@ -29,7 +29,7 @@ const Page = (props: PageProps) => {
     const fetchData = async () => {
       try {
         const tasData = await getUsers(course.tas);
-        const studentData = await getUsers(course.students);
+        const studentData = await getUsers(course.students.slice(0, 10));
         setTAs(tasData);
         setStudents(studentData);
       } catch (error) {

--- a/src/app/services/client/user.ts
+++ b/src/app/services/client/user.ts
@@ -45,14 +45,29 @@ export const getUser = async (
 export const getUsers = async (
   userIds: string[]
 ): Promise<IdentifiableUsers> => {
-  const q = query(
-    collection(db, "users").withConverter(userConverter),
-    where(documentId(), "in", userIds)
-  );
-  const users = await getDocs(q);
-  return users.docs
-    .filter((doc) => doc.exists)
-    .map((doc) => ({ ...doc.data(), id: doc.id }));
+  if (userIds.length === 0) {
+    return [];
+  }
+
+  const chunks = [];
+  const chunkSize = 30;
+
+  for (let i = 0; i < userIds.length; i += chunkSize) {
+    chunks.push(userIds.slice(i, i + chunkSize));
+  }
+
+  const userPromises = chunks.map(async (chunk) => {
+    const q = query(
+      collection(db, "users").withConverter(userConverter),
+      where(documentId(), "in", chunk)
+    );
+    const users = await getDocs(q);
+    return users.docs
+      .filter((doc) => doc.exists())
+      .map((doc) => ({ ...doc.data(), id: doc.id }));
+  });
+  const userChunks = await Promise.all(userPromises);
+  return userChunks.flat();
 };
 
 export const updateUser = async (user: IdentifiableUser) => {


### PR DESCRIPTION
# Description
Quick hotfix for getUsers fetching. The "IN" condition for a list of queries has a limit of 30, so this PR handles chunking the getUsers and also on the fetches 10 students on the `/course/[courseId]` page (rather than all users).

<img width="495" alt="image" src="https://github.com/user-attachments/assets/8a8caf43-6f20-4255-be87-8fed5170c672" />

<img width="600" alt="image" src="https://github.com/user-attachments/assets/f4bcba22-7700-4678-b968-39e8b9a0682c" />

# Test
Go through the references of getUsers and see if they function the same. 
