### PR TITLE
Loading Fix and Render Hook Too Early

### DIFF
--- a/src/app/components/AnnouncementTile.tsx
+++ b/src/app/components/AnnouncementTile.tsx
@@ -1,3 +1,5 @@
+"use client";
+
 import { Box, Button, IconButton, TextField, Typography } from "@mui/material";
 import theme from "theme";
 import DeleteOutlineIcon from "@mui/icons-material/DeleteOutline";

--- a/src/app/components/DisplayLocHours.tsx
+++ b/src/app/components/DisplayLocHours.tsx
@@ -114,7 +114,7 @@ export const DisplayLocHours = (props: DisplayLocHoursProps) => {
         ) : (
           <Typography
             variant="body2"
-            color={theme.palette.text.secondary}
+            color={theme.palette.text.primary}
             sx={{ whiteSpace: "pre-line" }}
           >
             {renderWithLinks(currLocation)}

--- a/src/app/components/EnrolledCourses.tsx
+++ b/src/app/components/EnrolledCourses.tsx
@@ -15,8 +15,8 @@ export const EnrolledCourses = () => {
   const router = useRouter();
   const user = useUserOrRedirect();
   const [courses, setCourses] = React.useState<IdentifiableCourses>([]);
-  // const [fetching, setFetching] = React.useState(true);
   const { setLoading } = useLoading();
+
   React.useEffect(() => {
     const fetchCourses = async () => {
       if (user && user.courses.length > 0) {

--- a/src/app/components/EnrolledCourses.tsx
+++ b/src/app/components/EnrolledCourses.tsx
@@ -9,34 +9,28 @@ import { Box, Button, IconButton, Typography } from "@mui/material";
 import React from "react";
 import { getUserCourses } from "@services/client/course";
 import { CourseCard } from "./CourseCard";
-import Spinner from "./Spinner";
+import { useLoading } from "@context/LoadingContext";
 
 export const EnrolledCourses = () => {
   const router = useRouter();
   const user = useUserOrRedirect();
   const [courses, setCourses] = React.useState<IdentifiableCourses>([]);
-  const [fetching, setFetching] = React.useState(true);
-
+  // const [fetching, setFetching] = React.useState(true);
+  const { setLoading } = useLoading();
   React.useEffect(() => {
     const fetchCourses = async () => {
       if (user && user.courses.length > 0) {
-        setFetching(true);
+        setLoading(true);
         const fetchedCourses = await getUserCourses(user);
         setCourses(fetchedCourses);
+        setLoading(false);
       }
-      setFetching(false);
     };
     fetchCourses();
   }, [user]);
-
-  if (!user || fetching) {
-    return (
-      <Box className="flex flex-col h-screen items-center justify-center">
-        <Spinner width={64} height={64} />;
-      </Box>
-    );
+  if (!user) {
+    return null;
   }
-
   return (
     <Box className="flex flex-col h-screen">
       <Header

--- a/src/app/components/board/QuestionDetails.tsx
+++ b/src/app/components/board/QuestionDetails.tsx
@@ -25,7 +25,6 @@ import useApiThrottle from "@hooks/useApiThrottle";
 import { useUserOrRedirect } from "@hooks/useUserOrRedirect";
 import { serverTimestamp, Timestamp } from "firebase/firestore";
 import { sendEmail } from "@api/send-email/route.client";
-import { useLoading } from "@context/LoadingContext";
 
 interface QuestionDetailsProps {
   question: IdentifiableQuestion;
@@ -46,7 +45,6 @@ export const QuestionDetails = (props: QuestionDetailsProps) => {
 
   const user = useUserOrRedirect();
   const router = useRouter();
-  const { setLoading } = useLoading();
 
   const [joinGroup, setJoinGroup] = React.useState<boolean>(
     question.group.includes(user!.id)
@@ -55,13 +53,12 @@ export const QuestionDetails = (props: QuestionDetailsProps) => {
 
   React.useEffect(() => {
     const fetchUsers = async () => {
-      setLoading(true);
       const fetchedUsers = await getUsers(question.group);
       setUsers(fetchedUsers);
-      setLoading(false);
     };
     fetchUsers();
   }, [question]);
+
   if (!user) {
     return null;
   }

--- a/src/app/context/UserSessionContext.tsx
+++ b/src/app/context/UserSessionContext.tsx
@@ -122,7 +122,6 @@ export const UserSessionContextProvider = ({
         error: null,
       });
       router.push("/login");
-      router.refresh();
     } catch (e: any) {
       setSession({
         isAuthenticated: false,

--- a/src/app/login/page.tsx
+++ b/src/app/login/page.tsx
@@ -1,7 +1,7 @@
 "use client";
 
 import { useUserSession } from "@context/UserSessionContext";
-import { Button, Typography } from "@mui/material";
+import { Box, Button, Typography } from "@mui/material";
 import { useRouter } from "next/navigation";
 import React from "react";
 
@@ -50,9 +50,9 @@ export default function Page() {
   }
 
   return (
-    <div className="flex items-center justify-center h-screen">
-      <div className="flex flex-col items-center">
-        <div className="flex gap-1.5 items-center">
+    <Box className="flex items-center justify-center h-screen">
+      <Box className="flex flex-col items-center">
+        <Box className="flex gap-1.5 items-center">
           <svg
             xmlns="http://www.w3.org/2000/svg"
             width="3.5em"
@@ -64,18 +64,25 @@ export default function Page() {
               d="M15 4a8 8 0 0 1 8 8a8 8 0 0 1-8 8a8 8 0 0 1-8-8a8 8 0 0 1 8-8m0 2a6 6 0 0 0-6 6a6 6 0 0 0 6 6a6 6 0 0 0 6-6a6 6 0 0 0-6-6m-1 2h1.5v3.78l2.33 2.33l-1.06 1.06L14 12.4zM2 18a1 1 0 0 1-1-1a1 1 0 0 1 1-1h3.83c.31.71.71 1.38 1.17 2zm1-5a1 1 0 0 1-1-1a1 1 0 0 1 1-1h2.05L5 12l.05 1zm1-5a1 1 0 0 1-1-1a1 1 0 0 1 1-1h3c-.46.62-.86 1.29-1.17 2z"
             />
           </svg>
-          <div className="text-4xl font-semibold">OfficeMinutes</div>
-        </div>
-        <div className="mt-1">Answers in minutes, Not hours</div>
+          <Typography variant="h4" sx={{ fontWeight: 600 }}>
+            OfficeMinutes
+          </Typography>
+        </Box>
+        <Typography variant="subtitle1">
+          Answers in minutes, Not hours
+        </Typography>
         <Button
           className="py-2.5 px-6 bg-[#38608F] rounded-full mt-6 normal-case"
           onClick={() => onSignIn()}
         >
-          <Typography variant="subtitle2" color="#FFFFFF" fontWeight={600}>
+          <Typography
+            variant="subtitle2"
+            sx={{ color: "#FFFFFF", fontWeight: 600 }}
+          >
             Get started
           </Typography>
         </Button>
-      </div>
-    </div>
+      </Box>
+    </Box>
   );
 }

--- a/src/app/private/course/[courseId]/queue/page.tsx
+++ b/src/app/private/course/[courseId]/queue/page.tsx
@@ -36,14 +36,6 @@ const Page = () => {
   const [closeQueueVisible, setCloseQueueVisible] =
     React.useState<boolean>(false);
 
-  if (!user) {
-    return null;
-  }
-  const isUserTA = course.tas.includes(user.id);
-  const { queuePos, groupPos, currQuestion, groupQuestion } = getQueuePosition(
-    questions,
-    user
-  );
   const queueClosed = course.onDuty.length === 0 || !course.isOpen;
 
   const changeQueueState = async (change: boolean) => {
@@ -62,7 +54,7 @@ const Page = () => {
       try {
         const helpingQuestion = questions.find(
           (question) =>
-            question.helpedBy === user.id &&
+            question.helpedBy === user!.id &&
             question.state === QuestionState.IN_PROGRESS
         );
         setHelpingQuestion(helpingQuestion);
@@ -83,13 +75,15 @@ const Page = () => {
     fetchData();
   }, [questions]);
 
-  React.useEffect(() => {
-    const interval = setInterval(() => {
-      setTime(timeSince(helpingQuestion?.helpedAt));
-    }, 1000);
+  if (!user) {
+    return null;
+  }
 
-    return () => clearInterval(interval);
-  }, [helpingQuestion?.helpedAt]);
+  const isUserTA = course.tas.includes(user.id);
+  const { queuePos, groupPos, currQuestion, groupQuestion } = getQueuePosition(
+    questions,
+    user
+  );
 
   const closeButtons = [
     {


### PR DESCRIPTION
# Description

<!-- Include a summary of your changes -->

Before this PR, the `private/course/page.tsx` was facing this issue because the Page returned before the hooks mounted.

I also remove the loading from the QuestionDetails because when someone joins or leaves groups we shouldn't render the Spinner for a few ms. 

Small UI changes here and there. 

Added Loading Spinner to EnrolledCourses

<img width="313" alt="Unhandled Runtime Erron" src="https://github.com/user-attachments/assets/0ce84f06-8af4-4667-8af7-7c4228801d0f" />

# Test
Visit EnrolledCourse, Queue Page, and Sign in and Out.
