### PR TITLE
Fix timer and being helped screen

### DIFF
--- a/src/app/components/queue/EditQuestion.tsx
+++ b/src/app/components/queue/EditQuestion.tsx
@@ -1,3 +1,4 @@
+"use client";
 import { Box, Button, Container, Typography } from "@mui/material";
 import NotificationAddOutlinedIcon from "@mui/icons-material/NotificationAddOutlined";
 import KeyboardReturnOutlinedIcon from "@mui/icons-material/KeyboardReturnOutlined";
@@ -41,13 +42,13 @@ export const EditQuestion = (props: EditQuestionProps) => {
   }, [course]);
 
   const user = useUserOrRedirect();
-  if (!user || queuePos === -1) {
+
+  if (!user || tas.length === 0) {
     return null;
   }
 
   if (currQuestion.helpedBy !== "") {
     const ta = tas.find((myTa) => myTa.id === currQuestion.helpedBy);
-
     return (
       <Box
         sx={{

--- a/src/app/private/course/[courseId]/queue/page.tsx
+++ b/src/app/private/course/[courseId]/queue/page.tsx
@@ -73,7 +73,15 @@ const Page = () => {
     };
 
     fetchData();
-  }, [questions]);
+  }, [questions, user]);
+
+  React.useEffect(() => {
+    const interval = setInterval(() => {
+      setTime(timeSince(helpingQuestion?.helpedAt));
+    }, 1000);
+
+    return () => clearInterval(interval);
+  }, [helpingQuestion]);
 
   if (!user) {
     return null;


### PR DESCRIPTION
# Description

Prior to this PR, the queuePosition === -1 check meant the student being helped screen was not shown. Also somehow the setInterval for timer updates was removed in merging.

<img width="306" alt="image" src="https://github.com/user-attachments/assets/da37c04e-ced9-49f7-8052-cbb5cd931fe6" />

<!-- Include a summary of your changes -->

# Test
1. Make a question at a student. 
2. Use Ta account to start helping. 
3. See if timer on Ta screen is incrementing.
4. See if student's screen displays the right "Being helped screen". 