### PR TITLE
bug: private question access restriction

### DIFF
--- a/src/app/hooks/oh/useQuestionAccessCheck.ts
+++ b/src/app/hooks/oh/useQuestionAccessCheck.ts
@@ -22,7 +22,7 @@ export const useQuestionAccessCheck = (
 
   useEffect(() => {
     if (!user || !course) {
-      throw new Error();
+      return;
     }
 
     if (
@@ -36,10 +36,6 @@ export const useQuestionAccessCheck = (
     setIsUserTA(course.tas.includes(user.id));
     setIsLoading(false);
   }, [user, course, question]);
-
-  if (!question) {
-    throw new Error();
-  }
 
   return { isUserTA, question, isLoading };
 };

--- a/src/app/hooks/oh/useQuestionAccessCheck.ts
+++ b/src/app/hooks/oh/useQuestionAccessCheck.ts
@@ -1,0 +1,45 @@
+"use client";
+
+import { useOfficeHour } from "@hooks/oh/useOfficeHour";
+import { useUserOrRedirect } from "@hooks/useUserOrRedirect";
+import { useRouter } from "next/navigation";
+import { useMemo, useState, useEffect } from "react";
+
+export const useQuestionAccessCheck = (
+  questionId: string,
+  callbackUrl: string
+) => {
+  const router = useRouter();
+  const user = useUserOrRedirect();
+  const { course, questions } = useOfficeHour();
+  const [isUserTA, setIsUserTA] = useState(false);
+  const [isLoading, setIsLoading] = useState(true);
+
+  const question = useMemo(
+    () => questions.find((q) => q.id === questionId),
+    [questions, questionId]
+  );
+
+  useEffect(() => {
+    if (!user || !course) {
+      throw new Error();
+    }
+
+    if (
+      !question ||
+      (!question.questionPublic && !question.group.includes(user.id))
+    ) {
+      router.replace(callbackUrl);
+      return;
+    }
+
+    setIsUserTA(course.tas.includes(user.id));
+    setIsLoading(false);
+  }, [user, course, question]);
+
+  if (!question) {
+    throw new Error();
+  }
+
+  return { isUserTA, question, isLoading };
+};

--- a/src/app/private/course/[courseId]/board/[questionId]/page.tsx
+++ b/src/app/private/course/[courseId]/board/[questionId]/page.tsx
@@ -4,6 +4,8 @@ import Header from "@components/Header";
 import { ArrowBack } from "@mui/icons-material";
 import { useQuestionAccessCheck } from "@hooks/oh/useQuestionAccessCheck";
 import Link from "next/link";
+import { hasPassed } from "@utils/index";
+import { useRouter } from "next/navigation";
 
 interface PageProps {
   params: {
@@ -17,9 +19,15 @@ const Page = (props: PageProps) => {
     params: { courseId, questionId },
   } = props;
   const backUrl = `/private/course/${courseId}/board`;
+  const router = useRouter();
   const { question, isLoading } = useQuestionAccessCheck(questionId, backUrl);
 
   if (!question || isLoading) {
+    return null;
+  }
+
+  if (hasPassed(question)) {
+    router.push(backUrl);
     return null;
   }
 

--- a/src/app/private/course/[courseId]/board/[questionId]/page.tsx
+++ b/src/app/private/course/[courseId]/board/[questionId]/page.tsx
@@ -1,10 +1,10 @@
 "use client";
 import { QuestionDetails } from "@components/board/QuestionDetails";
 import Header from "@components/Header";
-import { useOfficeHour } from "@hooks/oh/useOfficeHour";
 import { ArrowBack } from "@mui/icons-material";
-import { useRouter } from "next/navigation";
+import { useQuestionAccessCheck } from "@hooks/oh/useQuestionAccessCheck";
 import Link from "next/link";
+import GlobalLoading from "@components/GlobalLoading";
 
 interface PageProps {
   params: {
@@ -17,20 +17,18 @@ const Page = (props: PageProps) => {
   const {
     params: { courseId, questionId },
   } = props;
-  const { questions } = useOfficeHour();
-  const question = questions.find((q) => q.id === questionId);
-  const router = useRouter();
+  const backUrl = `/private/course/${courseId}/board`;
+  const { question, isLoading } = useQuestionAccessCheck(questionId, backUrl);
 
-  if (!question) {
-    router.push(`/private/course/${courseId}/board`);
-    return;
+  if (isLoading) {
+    return <GlobalLoading />;
   }
 
   return (
     <div>
       <Header
         leftIcon={
-          <Link href={`/private/course/${courseId}/board`}>
+          <Link href={backUrl}>
             <ArrowBack sx={{ marginRight: "10px", color: "#000" }} />
           </Link>
         }

--- a/src/app/private/course/[courseId]/board/[questionId]/page.tsx
+++ b/src/app/private/course/[courseId]/board/[questionId]/page.tsx
@@ -4,7 +4,6 @@ import Header from "@components/Header";
 import { ArrowBack } from "@mui/icons-material";
 import { useQuestionAccessCheck } from "@hooks/oh/useQuestionAccessCheck";
 import Link from "next/link";
-import GlobalLoading from "@components/GlobalLoading";
 
 interface PageProps {
   params: {
@@ -20,8 +19,8 @@ const Page = (props: PageProps) => {
   const backUrl = `/private/course/${courseId}/board`;
   const { question, isLoading } = useQuestionAccessCheck(questionId, backUrl);
 
-  if (isLoading) {
-    return <GlobalLoading />;
+  if (!question || isLoading) {
+    return null;
   }
 
   return (

--- a/src/app/private/course/[courseId]/board/history/[questionId]/page.tsx
+++ b/src/app/private/course/[courseId]/board/history/[questionId]/page.tsx
@@ -1,0 +1,44 @@
+"use client";
+import { QuestionDetails } from "@components/board/QuestionDetails";
+import Header from "@components/Header";
+import { ArrowBack } from "@mui/icons-material";
+import Link from "next/link";
+import { useQuestionAccessCheck } from "@hooks/oh/useQuestionAccessCheck";
+
+interface PageProps {
+  params: {
+    courseId: string;
+    questionId: string;
+  };
+}
+
+const Page = (props: PageProps) => {
+  const {
+    params: { courseId, questionId },
+  } = props;
+  const backUrl = `/private/course/${courseId}/board/history`;
+  const { question, isLoading } = useQuestionAccessCheck(questionId, backUrl);
+
+  if (!question || isLoading) {
+    return null;
+  }
+
+  return (
+    <div>
+      <Header
+        leftIcon={
+          <Link href={backUrl}>
+            <ArrowBack sx={{ marginLeft: "-10px", color: "#000" }} />
+          </Link>
+        }
+      />
+      <QuestionDetails
+        courseId={courseId}
+        question={question}
+        fromTAQueue={false}
+      />
+    </div>
+  );
+};
+
+export default Page;

--- a/src/app/private/course/[courseId]/board/history/page.tsx
+++ b/src/app/private/course/[courseId]/board/history/page.tsx
@@ -6,8 +6,11 @@ import { useUserOrRedirect } from "@hooks/useUserOrRedirect";
 import { ArrowBack } from "@mui/icons-material";
 import { Box, Typography } from "@mui/material";
 import { getExpiredQuestions } from "@utils/index";
+import { getQuestions } from "@services/client/question";
 import Link from "next/link";
 import React from "react";
+import { IdentifiableQuestions } from "@interfaces/type";
+import { useLoading } from "@context/LoadingContext";
 
 interface PageProps {
   params: {
@@ -17,14 +20,28 @@ interface PageProps {
 
 const Page = (props: PageProps) => {
   const { courseId } = props.params;
-  const { course, questions } = useOfficeHour();
+  const { course } = useOfficeHour();
+  const { setLoading } = useLoading();
+  const [expiredQuestions, setExpiredQuestions] =
+    React.useState<IdentifiableQuestions>([]);
   const user = useUserOrRedirect();
+
+  React.useEffect(() => {
+    const fetchQuestions = async () => {
+      setLoading(true);
+      const allQuestions = await getQuestions(courseId);
+      const expiredQuestions = getExpiredQuestions(allQuestions);
+      setExpiredQuestions(expiredQuestions);
+      setLoading(false);
+    };
+    fetchQuestions();
+  }, []);
+
   if (!user) {
     return null;
   }
 
   const isUserTA = course.tas.includes(user.id);
-  const expiredQuestions = getExpiredQuestions(questions);
 
   return (
     <Box>

--- a/src/app/private/course/[courseId]/board/page.tsx
+++ b/src/app/private/course/[courseId]/board/page.tsx
@@ -43,9 +43,7 @@ const Page = (props: PageProps) => {
                 textWrap: "nowrap",
               }}
             >
-              <Typography variant="subtitle2">
-                View {isUserTA ? "Response" : ""} History
-              </Typography>
+              <Typography variant="subtitle2">View History</Typography>
             </Button>
           </Link>
         }

--- a/src/app/private/course/[courseId]/queue/[questionId]/page.tsx
+++ b/src/app/private/course/[courseId]/queue/[questionId]/page.tsx
@@ -1,6 +1,5 @@
 "use client";
 import { QuestionDetails } from "@components/board/QuestionDetails";
-import GlobalLoading from "@components/GlobalLoading";
 import Header from "@components/Header";
 import { useQuestionAccessCheck } from "@hooks/oh/useQuestionAccessCheck";
 import { ArrowBack } from "@mui/icons-material";
@@ -23,8 +22,8 @@ const Page = (props: PageProps) => {
     backUrl
   );
 
-  if (isLoading) {
-    <GlobalLoading />;
+  if (isLoading || !question) {
+    return null;
   }
 
   return (

--- a/src/app/private/course/[courseId]/queue/[questionId]/page.tsx
+++ b/src/app/private/course/[courseId]/queue/[questionId]/page.tsx
@@ -1,8 +1,8 @@
 "use client";
 import { QuestionDetails } from "@components/board/QuestionDetails";
+import GlobalLoading from "@components/GlobalLoading";
 import Header from "@components/Header";
-import { useOfficeHour } from "@hooks/oh/useOfficeHour";
-import { useUserOrRedirect } from "@hooks/useUserOrRedirect";
+import { useQuestionAccessCheck } from "@hooks/oh/useQuestionAccessCheck";
 import { ArrowBack } from "@mui/icons-material";
 import Link from "next/link";
 
@@ -17,23 +17,21 @@ const Page = (props: PageProps) => {
   const {
     params: { courseId, questionId },
   } = props;
-  const { course, questions } = useOfficeHour();
-  const user = useUserOrRedirect();
-  if (!user) {
-    return null;
-  }
-  const isUserTA = course.tas.includes(user.id);
-  const question = questions.find((q) => q.id === questionId);
+  const backUrl = `/private/course/${courseId}/queue`;
+  const { isUserTA, question, isLoading } = useQuestionAccessCheck(
+    questionId,
+    backUrl
+  );
 
-  if (!question) {
-    throw new Error();
+  if (isLoading) {
+    <GlobalLoading />;
   }
 
   return (
     <div>
       <Header
         leftIcon={
-          <Link href={`/private/course/${courseId}/queue`}>
+          <Link href={backUrl}>
             <ArrowBack sx={{ marginRight: "10px", color: "#000" }} />
           </Link>
         }


### PR DESCRIPTION
# Description

Previously, users are able to go to private question via URL regardless of if they made the question or not. This PR addresses that with:

- a hook that checks for question validity + user is a part of that question
- hook returns isUserTA, question, and loading state
- added board/history/[questionId] page

## Issues

#81 

## Screenshots

https://github.com/user-attachments/assets/f048c846-836f-414c-b3af-0f99ff138945

## Test

Tested the following on same course:

- 2 different users, one with private question, other trying to access private question through URL through queue
- single user, trying to access board question that exist & doesn't exist
- single user, trying to access board history question that exist & doesn't exist

## Possible Downsides

Not sure if this is the best way to handle it (please roast). Also not sure if I should be using loading context or not, lmk

## Additional Documentations

None!
