### PR TITLE
Fixed reload on join class bug + text field height

### DIFF
--- a/src/app/private/course/join/page.tsx
+++ b/src/app/private/course/join/page.tsx
@@ -20,10 +20,6 @@ const Page = () => {
   const [enrolledError, setEnrolledError] = React.useState(false);
   const [notFoundError, setNotFoundError] = React.useState(false);
 
-  if (!user) {
-    return null;
-  }
-
   const EnrolledButtons = [
     {
       text: "Ok",
@@ -120,6 +116,11 @@ const Page = () => {
           value={code}
           onChange={(event) => setCode(event.target.value)}
           autoComplete="off"
+          InputProps={{
+            style: {
+              minHeight: 54,
+            },
+          }}
         />
         <ul className="ps-5 text-[#545F70]">
           <li>

--- a/src/app/private/course/join/page.tsx
+++ b/src/app/private/course/join/page.tsx
@@ -123,7 +123,7 @@ const Page = () => {
           autoComplete="off"
           InputProps={{
             style: {
-              minHeight: 54,
+              height: 54,
             },
           }}
         />

--- a/src/app/private/course/join/page.tsx
+++ b/src/app/private/course/join/page.tsx
@@ -80,6 +80,11 @@ const Page = () => {
     fetching ||
     enrolledError ||
     notFoundError;
+
+  if (!user) {
+    return null;
+  }
+
   return (
     <div>
       <Header


### PR DESCRIPTION
# Description

Previously, the height of the `/private/course/join` page's join class TextField would be cut in half upon render. This PR ensures that the TextField stays its fixed height on render. It also addresses a bug found while developing where if you refresh on the `private/course/join` page, you get an `application error` where there was a hooks render mismatch due to the `useUserSessionOrDirect`.

## Issues

#100 

## Screenshots

Before:

https://github.com/user-attachments/assets/7848deb0-ab30-48cf-8aea-95da5033d78b



After:

https://github.com/user-attachments/assets/7d0de42b-7192-4449-8c6b-c1466b7c49c2





## Test

Refer to videos above 😼

## Possible Downsides

Note that in second video of Screenshots, on reload, the TextField increases by like 1px. Not sure why that is though.

## Additional Documentations

None!
