### PR TITLE
Fix Join Group Ordering

### DIFF
--- a/src/app/components/board/index.tsx
+++ b/src/app/components/board/index.tsx
@@ -1,10 +1,17 @@
 import { IdentifiableQuestions } from "@interfaces/type";
-import { Box, Stack, ToggleButton, ToggleButtonGroup } from "@mui/material";
+import {
+  Box,
+  Stack,
+  ToggleButton,
+  ToggleButtonGroup,
+  Typography,
+} from "@mui/material";
 import Question from "./Question";
 import { useOfficeHour } from "@hooks/oh/useOfficeHour";
 import React from "react";
 import CheckIcon from "@mui/icons-material/Check";
 import { getCourseTopicTags, sortQuestionsChronologically } from "@utils/index";
+import theme from "theme";
 
 interface BoardProps {
   questions: IdentifiableQuestions;
@@ -151,6 +158,15 @@ const Board = (props: BoardProps) => {
           ))}
         </Stack>
       </ToggleButtonGroup>
+      <Box sx={{ marginBottom: "16px" }}>
+        <Typography
+          variant="subtitle2"
+          color={theme.palette.text.secondary}
+          fontWeight={600}
+        >
+          You can join multiple public questions and have a private question.
+        </Typography>
+      </Box>
       <_Board
         questions={getQuestionsByTopic(selectedTopics)}
         isUserTA={isUserTA}

--- a/src/app/components/queue/form/QuestionForm.tsx
+++ b/src/app/components/queue/form/QuestionForm.tsx
@@ -360,7 +360,7 @@ const QuestionForm = (props: QuestionFormProps) => {
                           color="textSecondary"
                           sx={{ textWrap: "wrap", lineHeight: 1.4 }}
                         >
-                          Only you and the TA can view this question
+                          Only you and the TA can view this question.
                         </Typography>
                       </Box>
                     </Box>

--- a/src/app/services/client/user.ts
+++ b/src/app/services/client/user.ts
@@ -68,10 +68,10 @@ export const getUsers = async (
   });
   const userChunks = await Promise.all(userPromises);
   const fetchedUsers = userChunks.flat();
+  const userMap = new Map(fetchedUsers.map((user) => [user.id, user]));
   const sortedUsers = userIds
-    .map((id) => fetchedUsers.find((user) => user.id === id))
+    .map((id) => userMap.get(id))
     .filter((user) => user !== undefined) as IdentifiableUsers;
-
   return sortedUsers;
 };
 

--- a/src/app/services/client/user.ts
+++ b/src/app/services/client/user.ts
@@ -67,7 +67,12 @@ export const getUsers = async (
       .map((doc) => ({ ...doc.data(), id: doc.id }));
   });
   const userChunks = await Promise.all(userPromises);
-  return userChunks.flat();
+  const fetchedUsers = userChunks.flat();
+  const sortedUsers = userIds
+    .map((id) => fetchedUsers.find((user) => user.id === id))
+    .filter((user) => user !== undefined) as IdentifiableUsers;
+
+  return sortedUsers;
 };
 
 export const updateUser = async (user: IdentifiableUser) => {


### PR DESCRIPTION
# Description

#92 introduced chunk fetching to get around Firebase's 30 query limit with the `where in` clause. 
However, chunk fetching with `where in` does not guarantee ordering of the results unless we sort it back ourselves (in respective to the input userIds).


Also small UI request from designers for the text below the tags
<img width="292" alt="image" src="https://github.com/user-attachments/assets/b121079c-f7a5-4bde-9d17-cd8388e7b28b" />

<!-- Include a summary of your changes -->

## Issues
Solves #96, it wasn't an arrayUnion issue as checking the Firebase when joining group appends to the end of the array.
<!-- Reference the issue that you're working on (if exists) -->
<!-- When you references an issue, Github will automatically link the PR to Github -->
<!-- For example, "Resolve #1" links your PR to the first issue -->
<!-- For a full list of keywords, see here https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue -->


## Test
- Try with 2+ accounts to see test joining and leaving conditions (ex: join end of group, promote to leader, leave and delete question)
<!-- Describe how we can test your code -->

