### PR TITLE
Edit tags

### DIFF
--- a/src/app/components/DisplayIssueTags.tsx
+++ b/src/app/components/DisplayIssueTags.tsx
@@ -1,0 +1,239 @@
+import React, { useCallback, useState, useEffect } from "react";
+import { useOfficeHour } from "@hooks/oh/useOfficeHour";
+import { getCourseTopicTags } from "@utils/index";
+import {
+  Box,
+  Typography,
+  Button,
+  Chip,
+  TextField,
+  IconButton,
+  Snackbar,
+  Alert,
+  CircularProgress,
+} from "@mui/material";
+import theme from "theme";
+import CloseIcon from "@mui/icons-material/Close";
+import { addCourseTag, deleteCourseTag } from "@services/client/course";
+import useApiThrottle from "@hooks/useApiThrottle";
+
+interface DisplayIssueTagsProps {}
+
+const TAG_KEY = "Issue";
+
+export const DisplayIssueTags = (props: DisplayIssueTagsProps) => {
+  const { course } = useOfficeHour();
+  const topics = getCourseTopicTags(course.tags, TAG_KEY);
+  const [isEdit, setIsEdit] = useState<boolean>(false);
+  const [currentTag, setCurrentTag] = useState<string>("");
+  const [isLoading, setIsLoading] = useState<boolean>(false);
+  const [loadingTag, setLoadingTag] = useState<string>("");
+  const [error, setError] = useState<string>("");
+  const [showSnackbar, setShowSnackbar] = useState<boolean>(false);
+  const [snackbarMessage, setSnackbarMessage] = useState<string>("");
+  const [snackbarSeverity, setSnackbarSeverity] = useState<
+    "success" | "error" | "info" | "warning"
+  >("success");
+
+  useEffect(() => {
+    if (error) setError("");
+  }, [currentTag]);
+
+  const showNotification = useCallback(
+    (message: string, severity: "success" | "error" | "info" | "warning") => {
+      setSnackbarMessage(message);
+      setSnackbarSeverity(severity);
+      setShowSnackbar(true);
+    },
+    []
+  );
+
+  const handleCloseSnackbar = useCallback(() => {
+    setShowSnackbar(false);
+  }, []);
+
+  const submitTag = useCallback(async () => {
+    const trimmedTag = currentTag.trim();
+    if (trimmedTag === "") return;
+
+    if (topics.includes(trimmedTag)) {
+      setError("This tag already exists");
+      return;
+    }
+
+    try {
+      setIsLoading(true);
+      await addCourseTag(course.id, trimmedTag);
+      setCurrentTag("");
+      showNotification("Tag added successfully", "success");
+    } catch (err) {
+      console.error("Error adding tag:", err);
+      showNotification("Failed to add tag", "error");
+    } finally {
+      setIsLoading(false);
+    }
+  }, [currentTag, course.id, topics, showNotification]);
+
+  const { fetching, fn: throttledSubmitTag } = useApiThrottle({
+    fn: submitTag,
+  });
+
+  const handleKeyPress = useCallback(
+    (event: React.KeyboardEvent) => {
+      if (event.key === "Enter" && !fetching) {
+        throttledSubmitTag();
+      }
+    },
+    [throttledSubmitTag, fetching]
+  );
+
+  const handleDeleteTag = useCallback(
+    async (tag: string) => {
+      try {
+        setLoadingTag(tag);
+        await deleteCourseTag(course.id, tag);
+        showNotification("Tag deleted successfully", "success");
+      } catch (err) {
+        console.error("Error deleting tag:", err);
+        showNotification("Failed to delete tag", "error");
+      } finally {
+        setLoadingTag("");
+      }
+    },
+    [course.id, showNotification]
+  );
+
+  return (
+    <Box>
+      <Snackbar
+        open={showSnackbar}
+        autoHideDuration={4000}
+        onClose={handleCloseSnackbar}
+        anchorOrigin={{ vertical: "top", horizontal: "center" }}
+      >
+        <Alert
+          onClose={handleCloseSnackbar}
+          severity={snackbarSeverity}
+          sx={{ width: "100%" }}
+        >
+          {snackbarMessage}
+        </Alert>
+      </Snackbar>
+      <Box
+        sx={{
+          display: "flex",
+          alignItems: "center",
+          justifyContent: "space-between",
+          marginBottom: "16px",
+        }}
+      >
+        <Typography
+          variant="h6"
+          color={theme.palette.text.primary}
+          sx={{ fontWeight: "bold" }}
+        >
+          Tags
+        </Typography>
+        <Button
+          sx={{ textTransform: "none" }}
+          onClick={() => setIsEdit(!isEdit)}
+          disabled={isLoading}
+        >
+          <Typography color={"#38608F"} variant="subtitle2">
+            {isEdit ? "Done" : "Edit"}
+          </Typography>
+        </Button>
+      </Box>
+      {isEdit ? (
+        <Box
+          sx={{
+            display: "flex",
+            flexDirection: "column",
+          }}
+        >
+          <TextField
+            label="Add a new tag"
+            placeholder="Press enter after entering a tag"
+            focused
+            fullWidth
+            value={currentTag}
+            error={!!error}
+            helperText={error}
+            disabled={isLoading || fetching}
+            sx={{
+              "& .MuiInputBase-root": {
+                paddingY: "12px",
+              },
+            }}
+            onChange={(event: React.ChangeEvent<HTMLInputElement>) => {
+              setCurrentTag(event.target.value);
+            }}
+            onKeyDown={handleKeyPress}
+            InputProps={{
+              endAdornment:
+                isLoading || fetching ? <CircularProgress size={20} /> : null,
+            }}
+          />
+          <Box
+            sx={{
+              display: "flex",
+              flexWrap: "wrap",
+              gap: "8px",
+              marginTop: "20px",
+            }}
+          >
+            {topics.map((topic) => (
+              <Box
+                key={topic}
+                sx={{
+                  borderRadius: "8px",
+                  borderColor: "#73777F",
+                  paddingLeft: "16px",
+                  backgroundColor: "#F7F2FA",
+                  display: "flex",
+                  flexDirection: "row",
+                  alignItems: "center",
+                }}
+              >
+                <Typography color="#43474E" variant="subtitle2">
+                  {topic}
+                </Typography>
+                <IconButton
+                  onClick={() => handleDeleteTag(topic)}
+                  disabled={isLoading || loadingTag === topic}
+                >
+                  {loadingTag === topic ? (
+                    <CircularProgress size={16} sx={{ color: "#43474E" }} />
+                  ) : (
+                    <CloseIcon fontSize="small" sx={{ color: "#43474E" }} />
+                  )}
+                </IconButton>
+              </Box>
+            ))}
+          </Box>
+        </Box>
+      ) : (
+        <Box
+          sx={{
+            display: "flex",
+            flexWrap: "wrap",
+            gap: "8px",
+          }}
+        >
+          {topics.map((topic) => (
+            <Chip
+              key={topic}
+              sx={{
+                borderRadius: "8px",
+                padding: "6px",
+                borderColor: "#73777F",
+              }}
+              variant="outlined"
+              label={topic}
+            />
+          ))}
+        </Box>
+      )}
+    </Box>
+  );
+};

--- a/src/app/components/DisplayIssueTags.tsx
+++ b/src/app/components/DisplayIssueTags.tsx
@@ -14,6 +14,7 @@ import {
 } from "@mui/material";
 import theme from "theme";
 import CloseIcon from "@mui/icons-material/Close";
+import AddIcon from "@mui/icons-material/Add";
 import { addCourseTag, deleteCourseTag } from "@services/client/course";
 import useApiThrottle from "@hooks/useApiThrottle";
 
@@ -171,7 +172,17 @@ export const DisplayIssueTags = (props: DisplayIssueTagsProps) => {
             onKeyDown={handleKeyPress}
             InputProps={{
               endAdornment:
-                isLoading || fetching ? <CircularProgress size={20} /> : null,
+                isLoading || fetching ? (
+                  <CircularProgress size={20} />
+                ) : (
+                  <IconButton
+                    onClick={() => throttledSubmitTag()}
+                    disabled={isLoading || fetching}
+                    size="small"
+                  >
+                    <AddIcon fontSize="small" sx={{ color: "#38608F" }} />
+                  </IconButton>
+                ),
             }}
           />
           <Box

--- a/src/app/components/DisplayIssueTags.tsx
+++ b/src/app/components/DisplayIssueTags.tsx
@@ -23,7 +23,7 @@ const TAG_KEY = "Tags";
 
 export const DisplayIssueTags = (props: DisplayIssueTagsProps) => {
   const { course } = useOfficeHour();
-  const topics = getCourseTopicTags(course.tags, TAG_KEY);
+  const topics = getCourseTopicTags(course.tags[TAG_KEY].options);
   const [isEdit, setIsEdit] = useState<boolean>(false);
   const [currentTag, setCurrentTag] = useState<string>("");
   const [isLoading, setIsLoading] = useState<boolean>(false);
@@ -189,25 +189,29 @@ export const DisplayIssueTags = (props: DisplayIssueTagsProps) => {
                   borderRadius: "8px",
                   borderColor: "#73777F",
                   paddingLeft: "16px",
+                  paddingRight: topic === "Other" ? "16px" : "",
                   backgroundColor: "#F7F2FA",
                   display: "flex",
                   flexDirection: "row",
                   alignItems: "center",
+                  height: "36px",
                 }}
               >
                 <Typography color="#43474E" variant="subtitle2">
                   {topic}
                 </Typography>
-                <IconButton
-                  onClick={() => handleDeleteTag(topic)}
-                  disabled={isLoading || loadingTag === topic}
-                >
-                  {loadingTag === topic ? (
-                    <CircularProgress size={16} sx={{ color: "#43474E" }} />
-                  ) : (
-                    <CloseIcon fontSize="small" sx={{ color: "#43474E" }} />
-                  )}
-                </IconButton>
+                {topic !== "Other" && (
+                  <IconButton
+                    onClick={() => handleDeleteTag(topic)}
+                    disabled={isLoading || loadingTag === topic}
+                  >
+                    {loadingTag === topic ? (
+                      <CircularProgress size={16} sx={{ color: "#43474E" }} />
+                    ) : (
+                      <CloseIcon fontSize="small" sx={{ color: "#43474E" }} />
+                    )}
+                  </IconButton>
+                )}
               </Box>
             ))}
           </Box>

--- a/src/app/components/DisplayIssueTags.tsx
+++ b/src/app/components/DisplayIssueTags.tsx
@@ -19,7 +19,7 @@ import useApiThrottle from "@hooks/useApiThrottle";
 
 interface DisplayIssueTagsProps {}
 
-const TAG_KEY = "Issue";
+const TAG_KEY = "Tags";
 
 export const DisplayIssueTags = (props: DisplayIssueTagsProps) => {
   const { course } = useOfficeHour();

--- a/src/app/components/DisplayIssueTags.tsx
+++ b/src/app/components/DisplayIssueTags.tsx
@@ -79,9 +79,9 @@ export const DisplayIssueTags = (props: DisplayIssueTagsProps) => {
   });
 
   const handleKeyPress = useCallback(
-    (event: React.KeyboardEvent) => {
+    async (event: React.KeyboardEvent) => {
       if (event.key === "Enter" && !fetching) {
-        throttledSubmitTag();
+        await throttledSubmitTag();
       }
     },
     [throttledSubmitTag, fetching]

--- a/src/app/components/QuestionDetails.tsx
+++ b/src/app/components/QuestionDetails.tsx
@@ -2,7 +2,11 @@
 
 import { IdentifiableQuestion, IdentifiableUsers } from "@interfaces/type";
 import { Avatar, Box, Typography } from "@mui/material";
-import { formatTimeDifference, trimUserName } from "@utils/index";
+import {
+  formatTimeDifference,
+  getCourseTopicTags,
+  trimUserName,
+} from "@utils/index";
 import React from "react";
 import theme from "theme";
 import PeopleAltIcon from "@mui/icons-material/PeopleAlt";
@@ -94,10 +98,10 @@ export const QuestionDetails = (props: QuestionDetailsProps) => {
           </Typography>
         </Box>
         <Box marginTop="32px">
-          <Box display="flex" columnGap="16px" rowGap="8px" flexWrap="wrap">
-            {question.tags.map((tag) => (
+          <Box display="flex" columnGap="8px" rowGap="8px" flexWrap="wrap">
+            {getCourseTopicTags(question.tags).map((tag) => (
               <Box
-                key={tag.choice}
+                key={tag}
                 border={1}
                 borderColor="#73777F"
                 borderRadius="10px"
@@ -106,7 +110,7 @@ export const QuestionDetails = (props: QuestionDetailsProps) => {
                 color="#43474E"
               >
                 <Typography sx={{ fontWeight: 500, fontSize: 14 }}>
-                  {tag.choice}
+                  {tag}
                 </Typography>
               </Box>
             ))}

--- a/src/app/components/TADisplayCourse.tsx
+++ b/src/app/components/TADisplayCourse.tsx
@@ -8,6 +8,7 @@ import { useOfficeHour } from "@hooks/oh/useOfficeHour";
 import { DisplayAnnouncements } from "./DisplayAnnouncements";
 import React from "react";
 import { DisplayLocHours } from "./DisplayLocHours";
+import { DisplayIssueTags } from "./DisplayIssueTags";
 
 interface TADisplayCourseProps {
   tas: IdentifiableUsers;
@@ -29,6 +30,7 @@ const TADisplayCourse = (props: TADisplayCourseProps) => {
       }}
     >
       <DisplayAnnouncements announcements={course.announcements} editable />
+      <DisplayIssueTags />
       <DisplayLocHours location={course.location} editable />
       <Box
         sx={{

--- a/src/app/components/board/index.tsx
+++ b/src/app/components/board/index.tsx
@@ -19,7 +19,7 @@ interface BoardProps {
 }
 
 const SELECT_ALL = "All";
-const TAG_KEY = "Issue";
+const TAG_KEY = "Tags";
 
 const _Board = (props: BoardProps) => {
   const { questions } = props;

--- a/src/app/components/board/index.tsx
+++ b/src/app/components/board/index.tsx
@@ -61,7 +61,10 @@ const _Board = (props: BoardProps) => {
 const Board = (props: BoardProps) => {
   const { questions, isUserTA } = props;
   const { course } = useOfficeHour();
-  const topics = [SELECT_ALL, ...getCourseTopicTags(course.tags, TAG_KEY)];
+  const topics = [
+    SELECT_ALL,
+    ...getCourseTopicTags(course.tags[TAG_KEY].options),
+  ];
 
   const [selectedTopics, setSelectedTopics] = React.useState([SELECT_ALL]);
 

--- a/src/app/components/queue/form/QuestionForm.tsx
+++ b/src/app/components/queue/form/QuestionForm.tsx
@@ -40,7 +40,7 @@ const QuestionForm = (props: QuestionFormProps) => {
   const [openForm, setOpenForm] = React.useState(false);
   const { course } = useOfficeHour();
   const user = useUserOrRedirect();
-  const TAG_ORDER = ["General", "Issue", "How do you feel about the topic"];
+  const TAG_ORDER = ["General", "Tags", "How do you feel about the topic"];
 
   if (!user) {
     return null;

--- a/src/app/components/queue/form/Tags.tsx
+++ b/src/app/components/queue/form/Tags.tsx
@@ -10,6 +10,7 @@ import {
   RadioGroup,
   Typography,
 } from "@mui/material";
+import { getCourseTopicTags } from "@utils/index";
 import React from "react";
 import theme from "theme";
 
@@ -62,13 +63,13 @@ export const MultipleChoiceTags = (props: TagsProps) => {
           {tagsKey}
         </FormLabel>
         <Box sx={{ marginTop: 1 }}>
-          {tags.options.map((o) => (
+          {getCourseTopicTags(tags.options).map((tag) => (
             <Checkbox
               style={{ padding: 4 }}
-              key={o.choice}
+              key={tag}
               onChange={handleChange}
-              checked={state[o.choice]}
-              name={o.choice}
+              checked={state[tag]}
+              name={tag}
               icon={
                 <Button
                   sx={{
@@ -81,7 +82,7 @@ export const MultipleChoiceTags = (props: TagsProps) => {
                     textTransform: "none",
                   }}
                 >
-                  {o.choice}
+                  {tag}
                 </Button>
               }
               checkedIcon={
@@ -96,7 +97,7 @@ export const MultipleChoiceTags = (props: TagsProps) => {
                     textTransform: "none",
                   }}
                 >
-                  {o.choice}
+                  {tag}
                 </Button>
               }
             />
@@ -159,7 +160,19 @@ export const SingleChoiceTags = (props: TagsProps) => {
                     }}
                   />
                 }
-                label={<Typography>{o.choice}</Typography>}
+                label={
+                  <>
+                    <Typography>{o.choice}</Typography>
+                    {o.note && (
+                      <Typography
+                        fontSize={14}
+                        color={theme.palette.text.secondary}
+                      >
+                        {o.note}
+                      </Typography>
+                    )}
+                  </>
+                }
                 sx={{
                   marginY: 2,
                 }}

--- a/src/app/components/queue/form/Tags.tsx
+++ b/src/app/components/queue/form/Tags.tsx
@@ -159,19 +159,7 @@ export const SingleChoiceTags = (props: TagsProps) => {
                     }}
                   />
                 }
-                label={
-                  <>
-                    <Typography>{o.choice}</Typography>
-                    {o.note && (
-                      <Typography
-                        fontSize={14}
-                        color={theme.palette.text.secondary}
-                      >
-                        {o.note}
-                      </Typography>
-                    )}
-                  </>
-                }
+                label={<Typography>{o.choice}</Typography>}
                 sx={{
                   marginY: 2,
                 }}

--- a/src/app/interfaces/db.ts
+++ b/src/app/interfaces/db.ts
@@ -20,6 +20,7 @@ export interface Tags {
 
 export interface TagOption {
   choice: string;
+  note: string;
 }
 
 export interface Announcement {

--- a/src/app/interfaces/db.ts
+++ b/src/app/interfaces/db.ts
@@ -20,9 +20,6 @@ export interface Tags {
 
 export interface TagOption {
   choice: string;
-  note: string;
-  color: string;
-  colorFill: boolean;
 }
 
 export interface Announcement {

--- a/src/app/services/client/course.ts
+++ b/src/app/services/client/course.ts
@@ -223,6 +223,7 @@ export const addCourseTag = async (courseID: String, tag: String) => {
   await updateDoc(courseDoc, {
     "tags.Tags.options": arrayUnion({
       choice: tag,
+      note: "",
     }),
   });
 };
@@ -235,6 +236,7 @@ export const deleteCourseTag = async (courseID: string, tagName: string) => {
   await updateDoc(courseDoc, {
     "tags.Tags.options": arrayRemove({
       choice: tagName,
+      note: "",
     }),
   });
 };

--- a/src/app/services/client/course.ts
+++ b/src/app/services/client/course.ts
@@ -80,7 +80,7 @@ export const partialUpdateCourse = async (
   return courseId;
 };
 
-/* 
+/*
 Can't populate createdAt field with serverTimestamp because announcments
 is a list. Optimistically rely on client (tas) time for now.
 */
@@ -213,4 +213,38 @@ export const deleteCourse = async (courseID: String) => {
   );
 
   await deleteDoc(courseDoc);
+};
+
+export const addCourseTag = async (courseID: String, tag: String) => {
+  const courseDoc = doc(db, `courses/${courseID}`).withConverter(
+    courseConverter
+  );
+
+  const newTag = {
+    choice: tag,
+    color: "orange",
+    colorFill: false,
+    note: "",
+  };
+
+  await updateDoc(courseDoc, {
+    "tags.Issue.options": arrayUnion(newTag),
+  });
+};
+
+export const deleteCourseTag = async (courseID: string, tagName: string) => {
+  const courseDoc = doc(db, `courses/${courseID}`).withConverter(
+    courseConverter
+  );
+
+  const tagToRemove = {
+    choice: tagName,
+    color: "orange",
+    colorFill: false,
+    note: "",
+  };
+
+  await updateDoc(courseDoc, {
+    "tags.Issue.options": arrayRemove(tagToRemove),
+  });
 };

--- a/src/app/services/client/course.ts
+++ b/src/app/services/client/course.ts
@@ -221,7 +221,7 @@ export const addCourseTag = async (courseID: String, tag: String) => {
   );
 
   await updateDoc(courseDoc, {
-    "tags.Issue.options": arrayUnion({
+    "tags.Tags.options": arrayUnion({
       choice: tag,
     }),
   });
@@ -233,7 +233,7 @@ export const deleteCourseTag = async (courseID: string, tagName: string) => {
   );
 
   await updateDoc(courseDoc, {
-    "tags.Issue.options": arrayRemove({
+    "tags.Tags.options": arrayRemove({
       choice: tagName,
     }),
   });

--- a/src/app/services/client/course.ts
+++ b/src/app/services/client/course.ts
@@ -220,15 +220,10 @@ export const addCourseTag = async (courseID: String, tag: String) => {
     courseConverter
   );
 
-  const newTag = {
-    choice: tag,
-    color: "orange",
-    colorFill: false,
-    note: "",
-  };
-
   await updateDoc(courseDoc, {
-    "tags.Issue.options": arrayUnion(newTag),
+    "tags.Issue.options": arrayUnion({
+      choice: tag,
+    }),
   });
 };
 
@@ -237,14 +232,9 @@ export const deleteCourseTag = async (courseID: string, tagName: string) => {
     courseConverter
   );
 
-  const tagToRemove = {
-    choice: tagName,
-    color: "orange",
-    colorFill: false,
-    note: "",
-  };
-
   await updateDoc(courseDoc, {
-    "tags.Issue.options": arrayRemove(tagToRemove),
+    "tags.Issue.options": arrayRemove({
+      choice: tagName,
+    }),
   });
 };

--- a/src/app/utils/index.ts
+++ b/src/app/utils/index.ts
@@ -1,5 +1,5 @@
 import { defaultQuestion } from "@api/question";
-import { Announcement, QuestionState, Tags } from "@interfaces/db";
+import { Announcement, QuestionState, TagOption, Tags } from "@interfaces/db";
 import {
   IdentifiableQuestion,
   IdentifiableQuestions,
@@ -229,6 +229,9 @@ export const getEmailTemplate = (type: string, email: string) => {
   }
 };
 
-export const getCourseTopicTags = (tags: Tags, tagKey: string): string[] => {
-  return (tags[tagKey].options ?? []).map((option) => option.choice);
+export const getCourseTopicTags = (tags: TagOption[]): string[] => {
+  const choices = (tags ?? []).map((option) => option.choice);
+  const nonOtherTags = choices.filter((choice) => choice !== "Other");
+  const otherTags = choices.filter((choice) => choice === "Other");
+  return [...nonOtherTags, ...otherTags];
 };


### PR DESCRIPTION
# Description

Previously, there was no way to change the tags that are associated with a course. This PR adds the functionality to add & delete tags for a course and have it reflected in the Join Queue form as well as the board/history.

Note: added snackbar notifications (let me know if this should be removed)

## Issues

#72 

## Screenshots


https://github.com/user-attachments/assets/394f814c-9d09-4f06-a5fa-5becb3367965


## Test

Made a bunch of tags, verified it in the database, and checked that it was addable in both the join queue form as well as the board similar to video above.

## Possible Downsides

Might need to merge in #106 and #105 first since there is new structure of Description

## Additional Documentations

None!