### PR TITLE
New queue view

### DIFF
--- a/src/app/components/QuestionDetails.tsx
+++ b/src/app/components/QuestionDetails.tsx
@@ -94,13 +94,13 @@ export const QuestionDetails = (props: QuestionDetailsProps) => {
           </Typography>
         </Box>
         <Box marginTop="32px">
-          <Box display="flex" columnGap="16px" rowGap="8px" flexWrap="wrap">
+          <Box display="flex" gap="8px" flexWrap="wrap">
             {question.tags.map((tag) => (
               <Box
                 key={tag.choice}
                 border={1}
                 borderColor="#73777F"
-                borderRadius="10px"
+                borderRadius="8px"
                 paddingY="4px"
                 paddingX="14px"
                 color="#43474E"

--- a/src/app/components/TAQuestionButtons.tsx
+++ b/src/app/components/TAQuestionButtons.tsx
@@ -83,9 +83,15 @@ export const TAQuestionButtons = (props: TAQuestionButtonsProps) => {
   const onMissingRemove = async () => {
     if (question.state === QuestionState.PENDING) {
       await sendTopUserNotif();
-      await sendEmail(
-        getEmailTemplate("STUDENT_MISSING", groupUsers[0]?.email ?? "")
-      );
+      if (question.questionPublic) {
+        groupUsers.forEach(async (user) => {
+          await sendEmail(getEmailTemplate("GROUP_MISSING", user.email));
+        });
+      } else {
+        await sendEmail(
+          getEmailTemplate("STUDENT_MISSING", groupUsers[0]?.email ?? "")
+        );
+      }
       await partialUpdateQuestion(question.id, courseId, {
         state: QuestionState.MISSING,
       });

--- a/src/app/components/board/Question.tsx
+++ b/src/app/components/board/Question.tsx
@@ -110,13 +110,13 @@ const Question = (props: QuestionProps) => {
           </Typography>
         </Box>
         <Box marginTop="32px">
-          <Box display="flex" columnGap="16px" rowGap="8px" flexWrap="wrap">
+          <Box display="flex" gap="8px" flexWrap="wrap">
             {tagsToRender.map((tag) => (
               <Box
                 key={tag.choice}
                 border={1}
                 borderColor="#73777F"
-                borderRadius="10px"
+                borderRadius="8px"
                 paddingY="4px"
                 paddingX="14px"
                 color="#43474E"

--- a/src/app/components/queue/CreateQuestion.tsx
+++ b/src/app/components/queue/CreateQuestion.tsx
@@ -17,7 +17,7 @@ const CreateQuestion = () => {
   if (!user) {
     return null;
   }
-  const { queuePos } = getQueuePosition(questions, user);
+  const { privPos, groupPos } = getQueuePosition(questions, user);
   const [isModalVisible, setisModalVisible] = React.useState(false);
   const router = useRouter();
   const ModalButtons = [
@@ -57,7 +57,7 @@ const CreateQuestion = () => {
       text="Join queue"
       icon={<ArrowForwardOutlinedIcon />}
       onClick={() => {}}
-      disabled={queuePos !== -1}
+      disabled={privPos !== -1 && groupPos !== -1}
     />
   );
   return (

--- a/src/app/components/queue/CreateQuestion.tsx
+++ b/src/app/components/queue/CreateQuestion.tsx
@@ -66,6 +66,8 @@ const CreateQuestion = () => {
         triggerButton={triggerButton}
         title="Join queue"
         currentQuestion={defaultQuestion()}
+        isPrivExist={privPos !== -1}
+        isGroupExist={groupPos !== -1}
       />
     </Box>
   );

--- a/src/app/components/queue/CreateQuestion.tsx
+++ b/src/app/components/queue/CreateQuestion.tsx
@@ -60,12 +60,13 @@ const CreateQuestion = () => {
       disabled={privPos !== -1 && groupPos !== -1}
     />
   );
+  const newQuestion = { ...defaultQuestion(), questionPublic: groupPos === -1 };
   return (
     <Box>
       <QuestionForm
         triggerButton={triggerButton}
         title="Join queue"
-        currentQuestion={defaultQuestion()}
+        currentQuestion={newQuestion}
         isPrivExist={privPos !== -1}
         isGroupExist={groupPos !== -1}
       />

--- a/src/app/components/queue/EditQuestion.tsx
+++ b/src/app/components/queue/EditQuestion.tsx
@@ -70,7 +70,7 @@ export const EditQuestion = (props: EditQuestionProps) => {
 
   if (currQuestion.state === QuestionState.IN_PROGRESS) {
     const ta = tas.find((myTa) => myTa.id === currQuestion.helpedBy);
-    return ta ? <StudentHelping currQuestion={currQuestion} ta={ta} /> : null;
+    return ta && <StudentHelping currQuestion={currQuestion} ta={ta} />;
   }
 
   if (currQuestion.state === QuestionState.MISSING) {

--- a/src/app/components/queue/EditQuestion.tsx
+++ b/src/app/components/queue/EditQuestion.tsx
@@ -1,12 +1,9 @@
 "use client";
-import { Box, Button, Container, Typography } from "@mui/material";
-import NotificationAddOutlinedIcon from "@mui/icons-material/NotificationAddOutlined";
-import KeyboardReturnOutlinedIcon from "@mui/icons-material/KeyboardReturnOutlined";
+
 import { useOfficeHour } from "@hooks/oh/useOfficeHour";
 import React from "react";
 import { CustomModal } from "@components/CustomModal";
 import { leaveQuestionGroup } from "@services/client/question";
-import QuestionForm from "./form/QuestionForm";
 import { useUserOrRedirect } from "@hooks/useUserOrRedirect";
 import { IdentifiableQuestion, IdentifiableUsers } from "@interfaces/type";
 import { getUsers } from "@services/client/user";
@@ -14,6 +11,7 @@ import { useLoading } from "@context/LoadingContext";
 import { QuestionState } from "@interfaces/db";
 import { StudentHelping } from "./StudentHelping";
 import { StudentMissing } from "./StudentMissing";
+import { EditQuestionItem } from "./EditQuestionItem";
 
 interface EditQuestionProps {
   queuePos: number;
@@ -64,148 +62,61 @@ export const EditQuestion = (props: EditQuestionProps) => {
     },
   ];
 
-  const editButton = (
-    <Button
-      sx={{
-        fontWeight: 500,
-        fontSize: 14,
-        textTransform: "initial",
-        borderRadius: "100px",
-        flexGrow: 1,
-      }}
-      fullWidth
-      variant="outlined"
-    >
-      Edit submission
-    </Button>
-  );
-
   // not in queue, not join any question,
   // and not have any IN_PROGRESS or MISSING question
   if (queuePos === -1 && groupPos === -1 && currQuestion.title === "") {
     return null;
   }
 
-  const position =
-    queuePos === -1
-      ? groupPos
-      : groupPos === -1
-      ? queuePos
-      : Math.min(queuePos, groupPos);
-
-  const isAuthor = position === queuePos;
-
   if (currQuestion.state === QuestionState.IN_PROGRESS) {
     const ta = tas.find((myTa) => myTa.id === currQuestion.helpedBy);
-
-    if (!ta) {
-      return null;
-    }
-
-    return <StudentHelping currQuestion={currQuestion} ta={ta} />;
+    return ta ? <StudentHelping currQuestion={currQuestion} ta={ta} /> : null;
   }
+
   if (currQuestion.state === QuestionState.MISSING) {
     return <StudentMissing currQuestion={currQuestion} />;
   }
 
+  const questionsToDisplay = [];
+
+  if (queuePos !== -1) {
+    questionsToDisplay.push({
+      position: queuePos,
+      question: currQuestion,
+      leaveQueue: () => setLeaveQueueModal(true),
+    });
+  }
+
+  if (groupPos !== -1) {
+    questionsToDisplay.push({
+      position: groupPos,
+      question: groupQuestion,
+      leaveQueue: leaveGroup,
+    });
+  }
+
+  questionsToDisplay.sort((a, b) => a.position - b.position);
+
   return (
-    <>
-      {isAuthor && (
+    <React.Fragment>
+      {!currQuestion.questionPublic && (
         <CustomModal
           title="Leave queue?"
-          subtitle="You'll lose your place in line and
-                  won't receive assistance until you join again."
+          subtitle="You'll lose your place in line and won't receive assistance until you join again."
           buttons={leaveQueueButtons}
           open={leaveQueueModal}
           setOpen={setLeaveQueueModal}
         />
       )}
 
-      <Container
-        sx={{
-          bgcolor: "primary.light",
-          padding: "16px",
-          borderRadius: "12px",
-          display: "flex",
-          flexDirection: "column",
-          rowGap: "12px",
-          justifyContent: "space-around",
-          alignItems: "center",
-        }}
-      >
-        <Typography
-          sx={{ fontWeight: 400, fontSize: "16px", color: "#545F70" }}
-        >
-          Your queue position
-        </Typography>
-        <Typography
-          sx={{ fontWeight: 700, fontSize: "45px", textAlign: "center" }}
-        >
-          {position === 0 ? "You're next!" : position + 1}
-        </Typography>
-
-        <Box
-          sx={{
-            fontWeight: 400,
-            fontSize: 12,
-            display: "flex",
-            flexDirection: "row",
-            gap: 1,
-            color: "#545F70",
-            alignItems: "center",
-          }}
-        >
-          <NotificationAddOutlinedIcon style={{ fontSize: "16px" }} />
-          <Typography sx={{ fontSize: "16px" }}>
-            We'll notify you when it's your turn
-          </Typography>
-        </Box>
-        <Box
-          sx={{
-            display: "flex",
-            flexDirection: "row",
-            justifyContent: "space-between",
-            width: 1,
-            columnGap: "8px",
-            fontWeight: 500,
-            fontSize: "14px",
-            marginLeft: 2,
-            marginRight: 2,
-          }}
-        >
-          <Box sx={{ flexGrow: 1 }}>
-            <Button
-              variant="contained"
-              sx={{
-                fontWeight: 500,
-                fontSize: 14,
-                textTransform: "initial",
-                borderRadius: "100px",
-                display: "flex",
-                flexDirection: "row",
-                columnGap: 1,
-              }}
-              style={{ boxShadow: "none" }}
-              fullWidth
-              onClick={() =>
-                isAuthor ? setLeaveQueueModal(true) : leaveGroup()
-              }
-            >
-              <KeyboardReturnOutlinedIcon style={{ fontSize: "14px" }} />
-              {isAuthor ? "Leave queue " : "Leave group"}
-            </Button>
-          </Box>
-          {isAuthor && (
-            <Box sx={{ flexGrow: 1 }}>
-              <QuestionForm
-                triggerButton={editButton}
-                title="Edit submission"
-                currentQuestion={currQuestion}
-              />
-            </Box>
-          )}
-        </Box>
-      </Container>
-    </>
+      {questionsToDisplay.map((item, index) => (
+        <EditQuestionItem
+          key={index}
+          position={item.position}
+          question={item.question}
+          leaveQueue={item.leaveQueue}
+        />
+      ))}
+    </React.Fragment>
   );
 };

--- a/src/app/components/queue/EditQuestion.tsx
+++ b/src/app/components/queue/EditQuestion.tsx
@@ -31,7 +31,7 @@ export const EditQuestion = (props: EditQuestionProps) => {
     privQuestion,
     groupQuestion,
   } = props;
-  const { course } = useOfficeHour();
+  const { course, questions } = useOfficeHour();
   const [tas, setTas] = React.useState<IdentifiableUsers>([]);
   const [leaveQueueModal, setLeaveQueueModal] = React.useState<boolean>(false);
   const { setLoading } = useLoading();
@@ -53,7 +53,7 @@ export const EditQuestion = (props: EditQuestionProps) => {
   }
 
   const leaveQueue = async () => {
-    await leaveQuestionGroup(currQuestion, course.id, user.id);
+    await leaveQuestionGroup(privQuestion, course.id, user.id);
     setLeaveQueueModal(false);
   };
   const leaveGroup = async () => {
@@ -87,8 +87,27 @@ export const EditQuestion = (props: EditQuestionProps) => {
     return ta && <StudentHelping currQuestion={currQuestion} ta={ta} />;
   }
 
-  if (currQuestion.state === QuestionState.MISSING) {
-    return <StudentMissing currQuestion={currQuestion} />;
+  const missingPrivQuestion = currQuestion.state === QuestionState.MISSING;
+  const missingGroupQuestion = questions.find((q) => {
+    return (
+      q.questionPublic &&
+      q.state === QuestionState.MISSING &&
+      q.group.includes(user.id)
+    );
+  });
+
+  if (missingPrivQuestion || missingGroupQuestion) {
+    const missingQuestion = missingPrivQuestion
+      ? currQuestion
+      : missingGroupQuestion!;
+
+    return (
+      <StudentMissing
+        currQuestion={missingQuestion}
+        courseId={course.id}
+        userId={user.id}
+      />
+    );
   }
 
   const questionsToDisplay = [];

--- a/src/app/components/queue/EditQuestion.tsx
+++ b/src/app/components/queue/EditQuestion.tsx
@@ -15,13 +15,22 @@ import { EditQuestionItem } from "./EditQuestionItem";
 
 interface EditQuestionProps {
   queuePos: number;
+  privPos: number;
   groupPos: number;
   currQuestion: IdentifiableQuestion;
+  privQuestion: IdentifiableQuestion;
   groupQuestion: IdentifiableQuestion;
 }
 
 export const EditQuestion = (props: EditQuestionProps) => {
-  const { queuePos, groupPos, currQuestion, groupQuestion } = props;
+  const {
+    queuePos,
+    privPos,
+    groupPos,
+    currQuestion,
+    privQuestion,
+    groupQuestion,
+  } = props;
   const { course } = useOfficeHour();
   const [tas, setTas] = React.useState<IdentifiableUsers>([]);
   const [leaveQueueModal, setLeaveQueueModal] = React.useState<boolean>(false);
@@ -64,7 +73,12 @@ export const EditQuestion = (props: EditQuestionProps) => {
 
   // not in queue, not join any question,
   // and not have any IN_PROGRESS or MISSING question
-  if (queuePos === -1 && groupPos === -1 && currQuestion.title === "") {
+  if (
+    queuePos === -1 &&
+    privPos === -1 &&
+    groupPos === -1 &&
+    currQuestion.title === ""
+  ) {
     return null;
   }
 
@@ -79,10 +93,10 @@ export const EditQuestion = (props: EditQuestionProps) => {
 
   const questionsToDisplay = [];
 
-  if (queuePos !== -1) {
+  if (privPos !== -1) {
     questionsToDisplay.push({
-      position: queuePos,
-      question: currQuestion,
+      position: privPos,
+      question: privQuestion,
       leaveQueue: () => setLeaveQueueModal(true),
     });
   }
@@ -98,17 +112,17 @@ export const EditQuestion = (props: EditQuestionProps) => {
   questionsToDisplay.sort((a, b) => a.position - b.position);
 
   return (
-    <React.Fragment>
-      {!currQuestion.questionPublic && (
+    <>
+      {queuePos !== -1 && (
         <CustomModal
           title="Leave queue?"
-          subtitle="You'll lose your place in line and won't receive assistance until you join again."
+          subtitle="You'll lose your place in line and
+                  won't receive assistance until you join again."
           buttons={leaveQueueButtons}
           open={leaveQueueModal}
           setOpen={setLeaveQueueModal}
         />
       )}
-
       {questionsToDisplay.map((item, index) => (
         <EditQuestionItem
           key={index}
@@ -117,6 +131,6 @@ export const EditQuestion = (props: EditQuestionProps) => {
           leaveQueue={item.leaveQueue}
         />
       ))}
-    </React.Fragment>
+    </>
   );
 };

--- a/src/app/components/queue/EditQuestionItem.tsx
+++ b/src/app/components/queue/EditQuestionItem.tsx
@@ -105,7 +105,9 @@ export const EditQuestionItem = (props: EditQuestionItemProps) => {
             onClick={() => leaveQueue(true)}
             aria-label={isPrivate ? "Leave queue" : "Leave group"}
           >
-            <KeyboardReturnOutlinedIcon style={{ fontSize: "14px" }} />
+            <KeyboardReturnOutlinedIcon
+              style={{ fontSize: "14px", marginRight: "8px" }}
+            />
             {isPrivate ? "Leave queue " : "Leave group"}
           </Button>
           <Button
@@ -156,14 +158,25 @@ export const EditQuestionItem = (props: EditQuestionItemProps) => {
           id={`question-${question.id}-content`}
           aria-labelledby={`question-${question.id}-header`}
         >
-          <Typography sx={{ fontSize: 14, color: "#43474E" }}>
-            {users.map(trimUserName).join(", ")}
-          </Typography>
-          <Typography
-            sx={{ fontSize: "14px", color: "#43474E", marginTop: "10px" }}
-          >
+          <Typography sx={{ fontSize: "14px", color: "#43474E" }}>
             {question.description}
           </Typography>
+          <Box
+            sx={{
+              display: "flex",
+              justifyContent: "flex-end",
+              marginTop: "10px",
+              maxWidth: 0.6,
+              flexWrap: "wrap",
+              marginLeft: "auto",
+            }}
+          >
+            <Typography
+              sx={{ fontSize: 14, color: "#43474E", textAlign: "right" }}
+            >
+              {users.map(trimUserName).join(", ")}
+            </Typography>
+          </Box>
         </AccordionDetails>
       </Accordion>
     </Container>

--- a/src/app/components/queue/EditQuestionItem.tsx
+++ b/src/app/components/queue/EditQuestionItem.tsx
@@ -11,7 +11,7 @@ import {
   AccordionSummary,
 } from "@mui/material";
 import KeyboardReturnOutlinedIcon from "@mui/icons-material/KeyboardReturnOutlined";
-import KeyboardArrowUpIcon from "@mui/icons-material/KeyboardArrowUp";
+import KeyboardArrowDownIcon from "@mui/icons-material/KeyboardArrowDown";
 import React from "react";
 import { IdentifiableQuestion, IdentifiableUsers } from "@interfaces/type";
 import { getUsers } from "@services/client/user";
@@ -139,7 +139,7 @@ export const EditQuestionItem = (props: EditQuestionItemProps) => {
         }}
       >
         <AccordionSummary
-          expandIcon={<KeyboardArrowUpIcon sx={{ color: "#38608F" }} />}
+          expandIcon={<KeyboardArrowDownIcon sx={{ color: "#38608F" }} />}
           sx={{
             padding: 0,
             marginBottom: 0,

--- a/src/app/components/queue/EditQuestionItem.tsx
+++ b/src/app/components/queue/EditQuestionItem.tsx
@@ -1,0 +1,171 @@
+"use client";
+
+import {
+  Box,
+  Button,
+  Container,
+  Typography,
+  Divider,
+  Accordion,
+  AccordionDetails,
+  AccordionSummary,
+} from "@mui/material";
+import KeyboardReturnOutlinedIcon from "@mui/icons-material/KeyboardReturnOutlined";
+import KeyboardArrowUpIcon from "@mui/icons-material/KeyboardArrowUp";
+import React from "react";
+import { IdentifiableQuestion, IdentifiableUsers } from "@interfaces/type";
+import { getUsers } from "@services/client/user";
+import { trimUserName } from "@utils/index";
+
+interface EditQuestionItemProps {
+  position: number;
+  question: IdentifiableQuestion;
+  leaveQueue: (modal?: boolean) => void;
+}
+
+export const EditQuestionItem = (props: EditQuestionItemProps) => {
+  const { position, question, leaveQueue } = props;
+  const [users, setUsers] = React.useState<IdentifiableUsers>([]);
+  const isPrivate = !question.questionPublic;
+
+  React.useEffect(() => {
+    const fetchUsers = async () => {
+      const fetchedUsers = await getUsers(question.group);
+      setUsers(fetchedUsers);
+    };
+    fetchUsers();
+  }, [question.group]);
+
+  return (
+    <Container
+      sx={{
+        bgcolor: "primary.light",
+        paddingY: "16px",
+        borderRadius: "12px",
+        display: "flex",
+        flexDirection: "column",
+        rowGap: "12px",
+        justifyContent: "space-between",
+        alignItems: "center",
+      }}
+    >
+      <Container
+        sx={{
+          display: "flex",
+          flexDirection: "row",
+          rowGap: "10px",
+          padding: 0,
+        }}
+      >
+        <Box
+          sx={{
+            display: "flex",
+            flexDirection: "column",
+            textAlign: "center",
+            width: 1,
+          }}
+        >
+          <Typography
+            sx={{
+              fontWeight: 400,
+              fontSize: "12px",
+              color: "#545F70",
+              marginTop: "10px",
+            }}
+          >
+            {isPrivate ? "Private question" : "Your queue position"}
+          </Typography>
+          <Typography
+            sx={{ fontWeight: 700, fontSize: "45px", textAlign: "center" }}
+          >
+            {position + 1}
+          </Typography>
+        </Box>
+        <Box
+          sx={{
+            display: "flex",
+            flexDirection: "column",
+            justifyContent: "center",
+            rowGap: "10px",
+            width: 1,
+          }}
+        >
+          <Button
+            variant="contained"
+            sx={{
+              fontWeight: 500,
+              fontSize: 12,
+              textTransform: "initial",
+              borderRadius: "100px",
+              display: "flex",
+              flexDirection: "row",
+              boxShadow: "none",
+            }}
+            fullWidth
+            onClick={() => leaveQueue(true)}
+            aria-label={isPrivate ? "Leave queue" : "Leave group"}
+          >
+            <KeyboardReturnOutlinedIcon style={{ fontSize: "14px" }} />
+            {isPrivate ? "Leave queue " : "Leave group"}
+          </Button>
+          <Button
+            sx={{
+              fontWeight: 500,
+              fontSize: 12,
+              textTransform: "initial",
+              borderRadius: "100px",
+            }}
+            fullWidth
+            variant="outlined"
+            aria-label="Add to submission"
+          >
+            Add to submission
+          </Button>
+        </Box>
+      </Container>
+      <Divider flexItem />
+      <Accordion
+        disableGutters
+        sx={{
+          width: 1,
+          boxShadow: "none",
+          paddingX: "4px",
+          backgroundColor: "transparent",
+          "&.MuiAccordion-root": {
+            "&:before": {
+              display: "none",
+            },
+          },
+        }}
+      >
+        <AccordionSummary
+          expandIcon={<KeyboardArrowUpIcon sx={{ color: "#38608F" }} />}
+          sx={{
+            padding: 0,
+            marginBottom: 0,
+          }}
+          aria-controls={`question-${question.id}-content`}
+          id={`question-${question.id}-header`}
+        >
+          <Typography sx={{ fontWeight: 500, fontSize: "16px" }}>
+            {question.title}
+          </Typography>
+        </AccordionSummary>
+        <AccordionDetails
+          sx={{ padding: "0 0 8px 0" }}
+          id={`question-${question.id}-content`}
+          aria-labelledby={`question-${question.id}-header`}
+        >
+          <Typography sx={{ fontSize: 14, color: "#43474E" }}>
+            {users.map(trimUserName).join(", ")}
+          </Typography>
+          <Typography
+            sx={{ fontSize: "14px", color: "#43474E", marginTop: "10px" }}
+          >
+            {question.description}
+          </Typography>
+        </AccordionDetails>
+      </Accordion>
+    </Container>
+  );
+};

--- a/src/app/components/queue/EditQuestionItem.tsx
+++ b/src/app/components/queue/EditQuestionItem.tsx
@@ -172,9 +172,15 @@ export const EditQuestionItem = (props: EditQuestionItemProps) => {
             }}
           >
             <Typography
-              sx={{ fontSize: 14, color: "#43474E", textAlign: "right" }}
+              sx={{ fontSize: 12, color: "#545F70", textAlign: "right" }}
             >
-              {users.map(trimUserName).join(", ")}
+              {trimUserName(users[0])}
+              {users.length > 1 && (
+                <span>
+                  {" "}
+                  <strong>+ {users.length - 1}</strong> other(s)
+                </span>
+              )}
             </Typography>
           </Box>
         </AccordionDetails>

--- a/src/app/components/queue/EditQuestionItem.tsx
+++ b/src/app/components/queue/EditQuestionItem.tsx
@@ -147,7 +147,7 @@ export const EditQuestionItem = (props: EditQuestionItemProps) => {
           aria-controls={`question-${question.id}-content`}
           id={`question-${question.id}-header`}
         >
-          <Typography sx={{ fontWeight: 500, fontSize: "16px" }}>
+          <Typography sx={{ fontSize: "16px", color: "#191C20" }}>
             {question.title}
           </Typography>
         </AccordionSummary>

--- a/src/app/components/queue/StudentMissing.tsx
+++ b/src/app/components/queue/StudentMissing.tsx
@@ -1,66 +1,103 @@
 import { QuestionDetails } from "@components/QuestionDetails";
 import { IdentifiableQuestion } from "@interfaces/type";
 import ErrorOutlineOutlinedIcon from "@mui/icons-material/ErrorOutlineOutlined";
-import { Box } from "@mui/material";
+import KeyboardReturnOutlinedIcon from "@mui/icons-material/KeyboardReturnOutlined";
+import { Box, Button } from "@mui/material";
+import { leaveQuestionGroup } from "@services/client/question";
+import React from "react";
 
 interface StudentMissingProps {
   currQuestion: IdentifiableQuestion;
+  courseId: string;
+  userId: string;
 }
 
 export const StudentMissing = (props: StudentMissingProps) => {
-  const { currQuestion } = props;
+  const { currQuestion, courseId, userId } = props;
+
+  const leaveQueue = async () => {
+    await leaveQuestionGroup(currQuestion, courseId, userId);
+  };
 
   return (
-    <Box
-      sx={{
-        display: "flex",
-        flexDirection: "column",
-        gap: "10px",
-        color: "#43474E",
-      }}
-    >
+    <React.Fragment>
       <Box
         sx={{
           display: "flex",
-          flexDirection: "row",
-          columnGap: "10px",
-          padding: "16px",
-          bgcolor: "#FFDAD6",
-          justifyContent: "center",
-          marginLeft: "-16px",
-          marginTop: "-18px",
-          width: "100vw",
+          flexDirection: "column",
+          gap: "10px",
+          color: "#43474E",
         }}
       >
-        <ErrorOutlineOutlinedIcon
-          style={{ fontSize: "20px", color: "#FF0000" }}
-        />
-        <Box fontWeight={500} fontSize="14px">
-          You were marked as missing. Notify your TA.
+        <Box
+          sx={{
+            display: "flex",
+            flexDirection: "row",
+            columnGap: "10px",
+            padding: "16px",
+            bgcolor: "#FFDAD6",
+            justifyContent: "center",
+            marginLeft: "-16px",
+            marginTop: "-18px",
+            width: "100vw",
+          }}
+        >
+          <ErrorOutlineOutlinedIcon
+            style={{ fontSize: "20px", color: "#FF0000" }}
+          />
+          <Box fontWeight={500} fontSize="14px">
+            {currQuestion.questionPublic ? "Your group was" : "You were"} marked
+            as missing. Notify your TA.
+          </Box>
+        </Box>
+
+        <Box
+          sx={{
+            paddingTop: "20px",
+            paddingRight: "10px",
+            paddingLeft: "10px",
+            fontWeight: 700,
+            color: "#545F70",
+            fontSize: "18.98px",
+          }}
+        >
+          Your Question
+        </Box>
+        <Box
+          sx={{
+            backgroundColor: "#F2F3FA",
+            padding: "24px",
+            borderRadius: "24px",
+          }}
+        >
+          <QuestionDetails question={currQuestion} showGroup />
+
+          <Button
+            variant="contained"
+            sx={{
+              fontWeight: 500,
+              fontSize: 14,
+              textTransform: "initial",
+              borderRadius: "100px",
+              display: "flex",
+              flexDirection: "row",
+              boxShadow: "none",
+              marginTop: "24px",
+              height: "40px",
+            }}
+            fullWidth
+            onClick={leaveQueue}
+            aria-label={
+              currQuestion.questionPublic ? "Leave group" : "Leave queue"
+            }
+          >
+            <KeyboardReturnOutlinedIcon
+              style={{ fontSize: "16px", marginRight: "8px" }}
+            />
+            {currQuestion.questionPublic ? "Leave group" : "Leave queue"}
+          </Button>
         </Box>
       </Box>
-
-      <Box
-        sx={{
-          paddingTop: "20px",
-          paddingRight: "10px",
-          paddingLeft: "10px",
-          fontWeight: 700,
-          color: "#545F70",
-          fontSize: "18.98px",
-        }}
-      >
-        Your Question
-      </Box>
-      <Box
-        sx={{
-          backgroundColor: "#F2F3FA",
-          padding: "24px",
-          borderRadius: "24px",
-        }}
-      >
-        <QuestionDetails question={currQuestion} showGroup />
-      </Box>
-    </Box>
+    </React.Fragment>
   );
 };

--- a/src/app/components/queue/StudentMissing.tsx
+++ b/src/app/components/queue/StudentMissing.tsx
@@ -86,7 +86,9 @@ export const StudentMissing = (props: StudentMissingProps) => {
               height: "40px",
             }}
             fullWidth
-            onClick={leaveQueue}
+            onClick={async () => {
+              await leaveQueue();
+            }}
             aria-label={
               currQuestion.questionPublic ? "Leave group" : "Leave queue"
             }

--- a/src/app/components/queue/form/QuestionForm.tsx
+++ b/src/app/components/queue/form/QuestionForm.tsx
@@ -33,10 +33,13 @@ interface QuestionFormProps {
   title: string;
   // current state of question
   currentQuestion: IdentifiableQuestion;
+  isPrivExist: boolean;
+  isGroupExist: boolean;
 }
 
 const QuestionForm = (props: QuestionFormProps) => {
-  const { triggerButton, title, currentQuestion } = props;
+  const { triggerButton, title, currentQuestion, isPrivExist, isGroupExist } =
+    props;
   const [openForm, setOpenForm] = React.useState(false);
   const { course } = useOfficeHour();
   const user = useUserOrRedirect();
@@ -291,7 +294,7 @@ const QuestionForm = (props: QuestionFormProps) => {
                         border: 0,
                       },
                   }}
-                  value={newQuestion.questionPublic ? 0 : 1}
+                  value={!isGroupExist ? 0 : 1}
                   onChange={(event) => {
                     const {
                       target: { value },
@@ -304,67 +307,71 @@ const QuestionForm = (props: QuestionFormProps) => {
                   input={<OutlinedInput />}
                   inputProps={{ "aria-label": "Without label" }}
                 >
-                  <MenuItem value={0}>
-                    <Box
-                      sx={{
-                        display: "flex",
-                        flexDirection: "row",
-                        gap: 2,
-                        alignItems: "center",
-                      }}
-                    >
-                      <PublicIcon sx={{ color: "#38608F" }} />
+                  {!isGroupExist && (
+                    <MenuItem value={0}>
                       <Box
                         sx={{
                           display: "flex",
-                          flexDirection: "column",
-                          gap: 0.4,
+                          flexDirection: "row",
+                          gap: 2,
+                          alignItems: "center",
                         }}
                       >
-                        <Typography variant="body1">
-                          Public Question (Default)
-                        </Typography>
-                        <Typography
-                          variant="caption"
-                          color="textSecondary"
-                          sx={{ textWrap: "wrap", lineHeight: 1.4 }}
+                        <PublicIcon sx={{ color: "#38608F" }} />
+                        <Box
+                          sx={{
+                            display: "flex",
+                            flexDirection: "column",
+                            gap: 0.4,
+                          }}
                         >
-                          Everyone can view and join this question. You can join
-                          multiple public questions.
-                        </Typography>
+                          <Typography variant="body1">
+                            Public Question (Default)
+                          </Typography>
+                          <Typography
+                            variant="caption"
+                            color="textSecondary"
+                            sx={{ textWrap: "wrap", lineHeight: 1.4 }}
+                          >
+                            Everyone can view and join this question. You can
+                            join multiple public questions.
+                          </Typography>
+                        </Box>
                       </Box>
-                    </Box>
-                  </MenuItem>
-                  <MenuItem value={1}>
-                    <Box
-                      sx={{
-                        display: "flex",
-                        flexDirection: "row",
-                        gap: 2,
-                        alignItems: "center",
-                      }}
-                    >
-                      <LockOutlinedIcon sx={{ color: "#38608F" }} />
+                    </MenuItem>
+                  )}
+                  {!isPrivExist && (
+                    <MenuItem value={1}>
                       <Box
                         sx={{
                           display: "flex",
-                          flexDirection: "column",
-                          gap: 0.4,
+                          flexDirection: "row",
+                          gap: 2,
+                          alignItems: "center",
                         }}
                       >
-                        <Typography variant="body1">
-                          Private Question
-                        </Typography>
-                        <Typography
-                          variant="caption"
-                          color="textSecondary"
-                          sx={{ textWrap: "wrap", lineHeight: 1.4 }}
+                        <LockOutlinedIcon sx={{ color: "#38608F" }} />
+                        <Box
+                          sx={{
+                            display: "flex",
+                            flexDirection: "column",
+                            gap: 0.4,
+                          }}
                         >
-                          Only you and the TA can view this question.
-                        </Typography>
+                          <Typography variant="body1">
+                            Private Question
+                          </Typography>
+                          <Typography
+                            variant="caption"
+                            color="textSecondary"
+                            sx={{ textWrap: "wrap", lineHeight: 1.4 }}
+                          >
+                            Only you and the TA can view this question.
+                          </Typography>
+                        </Box>
                       </Box>
-                    </Box>
-                  </MenuItem>
+                    </MenuItem>
+                  )}
                 </Select>
               </FormControl>
             </FormControl>

--- a/src/app/components/queue/form/QuestionForm.tsx
+++ b/src/app/components/queue/form/QuestionForm.tsx
@@ -159,11 +159,22 @@ const QuestionForm = (props: QuestionFormProps) => {
       ? "Please select all tags"
       : "All required fields are not filled";
 
+  const SelectValues = () => {
+    if (isGroupExist && !isPrivExist) {
+      return "private";
+    } else if (isPrivExist && !isGroupExist) {
+      return "public";
+    } else if (!isGroupExist && !isPrivExist) {
+      return newQuestion.questionPublic ? "public" : "private";
+    } else {
+      return "";
+    }
+  };
   return (
     <Box>
       {trigger}
 
-      <Drawer open={openForm} anchor="bottom">
+      <Drawer open={openForm} anchor="bottom" disableEnforceFocus>
         <CustomModal
           title={"There was an error"}
           subtitle={subtitle}
@@ -294,21 +305,21 @@ const QuestionForm = (props: QuestionFormProps) => {
                         border: 0,
                       },
                   }}
-                  value={!isGroupExist ? 0 : 1}
+                  value={SelectValues()}
                   onChange={(event) => {
                     const {
                       target: { value },
                     } = event;
                     setNewQuestion({
                       ...newQuestion,
-                      questionPublic: value === 0,
+                      questionPublic: value === "public",
                     });
                   }}
                   input={<OutlinedInput />}
                   inputProps={{ "aria-label": "Without label" }}
                 >
                   {!isGroupExist && (
-                    <MenuItem value={0}>
+                    <MenuItem value={"public"}>
                       <Box
                         sx={{
                           display: "flex",
@@ -341,7 +352,7 @@ const QuestionForm = (props: QuestionFormProps) => {
                     </MenuItem>
                   )}
                   {!isPrivExist && (
-                    <MenuItem value={1}>
+                    <MenuItem value={"private"}>
                       <Box
                         sx={{
                           display: "flex",

--- a/src/app/private/course/[courseId]/queue/page.tsx
+++ b/src/app/private/course/[courseId]/queue/page.tsx
@@ -24,7 +24,6 @@ import useApiThrottle from "@hooks/useApiThrottle";
 import { QuestionDetails } from "@components/QuestionDetails";
 import { CustomButton } from "@components/buttons/CustomButton";
 import { partialUpdateQuestion } from "@services/client/question";
-import { useRouter } from "next/navigation";
 
 const Page = () => {
   const user = useUserOrRedirect();
@@ -91,10 +90,14 @@ const Page = () => {
   }
 
   const isUserTA = course.tas.includes(user.id);
-  const { queuePos, groupPos, currQuestion, groupQuestion } = getQueuePosition(
-    questions,
-    user
-  );
+  const {
+    queuePos,
+    privPos,
+    groupPos,
+    currQuestion,
+    privQuestion,
+    groupQuestion,
+  } = getQueuePosition(questions, user);
 
   const closeButtons = [
     {
@@ -168,8 +171,10 @@ const Page = () => {
               {!queueClosed && (
                 <EditQuestion
                   queuePos={queuePos}
+                  privPos={privPos}
                   groupPos={groupPos}
                   currQuestion={currQuestion}
+                  privQuestion={privQuestion}
                   groupQuestion={groupQuestion}
                 />
               )}

--- a/src/app/utils/index.ts
+++ b/src/app/utils/index.ts
@@ -175,12 +175,12 @@ export const getQueuePosition = (
   // queue position in PENDING queue
 
   const pendingPos = sortedPendingQuestions.findIndex(
-    (q) => q.group[0] === user.id
+    (q) => !q.questionPublic && q.group[0] === user.id
   );
   return {
     queuePos: pendingPos,
     groupPos: groupPos,
-    currQuestion: sortedActiveQuestions[position] ?? defaultQuestion(),
+    currQuestion: sortedActiveQuestions[pendingPos] ?? defaultQuestion(),
     groupQuestion: sortedPendingQuestions[groupPos] ?? defaultQuestion(),
   };
 };

--- a/src/app/utils/index.ts
+++ b/src/app/utils/index.ts
@@ -168,8 +168,8 @@ export const getQueuePosition = (
   const position = sortedActiveQuestions.findIndex(
     (q) => q.group[0] === user.id
   );
-  const groupPos = sortedPendingQuestions.findIndex((q) =>
-    q.group.includes(user.id)
+  const groupPos = sortedPendingQuestions.findIndex(
+    (q) => q.questionPublic && q.group.includes(user.id)
   );
 
   // queue position in PENDING queue

--- a/src/app/utils/index.ts
+++ b/src/app/utils/index.ts
@@ -156,6 +156,11 @@ export const timeSince = (timestamp: Timestamp | undefined) => {
   return `${formattedMinutes}:${formattedSeconds}`;
 };
 
+/*
+  currQuestion: First active question (pending/in progress/missing)
+  privQuestion: First pending private question
+  groupQuestion: First pending group question
+*/
 export const getQueuePosition = (
   questions: IdentifiableQuestions,
   user: IdentifiableUser

--- a/src/app/utils/index.ts
+++ b/src/app/utils/index.ts
@@ -165,22 +165,25 @@ export const getQueuePosition = (
   const sortedPendingQuestions = sortedActiveQuestions.filter(
     (q) => q.state === QuestionState.PENDING
   );
-  const position = sortedActiveQuestions.findIndex(
-    (q) => q.group[0] === user.id
+  const position = sortedActiveQuestions.findIndex((q) =>
+    q.group.includes(user.id)
+  );
+  const privPos = sortedPendingQuestions.findIndex(
+    (q) => !q.questionPublic && q.group.includes(user.id)
   );
   const groupPos = sortedPendingQuestions.findIndex(
     (q) => q.questionPublic && q.group.includes(user.id)
   );
-
-  // queue position in PENDING queue
-
   const pendingPos = sortedPendingQuestions.findIndex(
-    (q) => !q.questionPublic && q.group[0] === user.id
+    (q) => q.group[0] === user.id
   );
+
   return {
     queuePos: pendingPos,
+    privPos: privPos,
     groupPos: groupPos,
-    currQuestion: sortedActiveQuestions[pendingPos] ?? defaultQuestion(),
+    currQuestion: sortedActiveQuestions[position] ?? defaultQuestion(),
+    privQuestion: sortedPendingQuestions[privPos] ?? defaultQuestion(),
     groupQuestion: sortedPendingQuestions[groupPos] ?? defaultQuestion(),
   };
 };

--- a/src/app/utils/index.ts
+++ b/src/app/utils/index.ts
@@ -223,6 +223,12 @@ export const getEmailTemplate = (type: string, email: string) => {
         subject: "You are marked as missing from the queue!",
         body: "Please let the TA know when you are back.",
       };
+    case "GROUP_MISSING":
+      return {
+        email,
+        subject: "Your group is marked as missing from the queue!",
+        body: "Please let the TA know.",
+      };
     default:
       return {
         email,


### PR DESCRIPTION
# Description

This PR implements new queue logic and views for students. Students view now has:
- Accordion dropdowns for questions on queue
- automatic queue placements based on the questions that they join/create
- handles priority in multiple group questions to show just the top

Note: add to submission is not implemented as it depends on #105 to be merged first

## Issues

https://www.figma.com/design/rGjxNWn0NenMKjGxNhC5i7/Office-Minutes-%5BSummer-2024%5D?node-id=2713-14372&t=V6HOHviOEDAPZFHy-0

## Screenshots


https://github.com/user-attachments/assets/40cb8bd2-002b-47a9-b80f-ff361df5037b



## Test

Create group and private questions. Join other group questions and test clicking dropdown and leaving and seeing the queue position update.

## Possible Downsides

As noted above: add to submission isn't working yet and pending other changes

## Additional Documentations

None